### PR TITLE
Fix: 몇 가지 수정사항

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@types/react-dom": "^17.0.0",
     "@types/react-router-dom": "^5.3.2",
     "axios": "^0.24.0",
+    "dotenv": "^10.0.0",
     "emotion": "^11.0.0",
     "framer-motion": "^4",
     "global": "^4.4.0",

--- a/src/components/PrecautionModal/GuideModal.tsx
+++ b/src/components/PrecautionModal/GuideModal.tsx
@@ -23,7 +23,7 @@ function GuideModal() {
       >
         청원 작성 요령 안내
       </Button>
-      <Modal isOpen={isOpen} onClose={onClose} size={'xl'}>
+      <Modal isOpen={isOpen} onClose={onClose} size={'xl'} isCentered>
         <ModalOverlay />
         <ModalContent>
           <ModalHeader m="15px"> GIST 청원, 이렇게 등록하세요</ModalHeader>

--- a/src/containers/Register/Register.tsx
+++ b/src/containers/Register/Register.tsx
@@ -29,10 +29,12 @@ const Register = (): JSX.Element => {
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    const gistAddress = '@gist.ac.kr'
-    const gmAddress = '@gm.gist.ac.kr'
-    if (!email.includes(gistAddress) || email.includes(gmAddress)) {
+    const emailRegex = /@(gm.)?gist.ac.kr$/
+    const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
+    if (!emailRegex.test(email)) {
       alert('이메일 주소를 확인해주세요')
+    } else if (!passwordRegex.test(password)) {
+      alert('영문과 숫자를 포함하여 8자리 이상의 비밀번호를 설정해주세요')
     } else if (password !== passwordCheck) {
       alert('비밀번호를 확인해주세요')
     }

--- a/src/containers/Register/Register.tsx
+++ b/src/containers/Register/Register.tsx
@@ -81,7 +81,7 @@ const Register = (): JSX.Element => {
               </InputLeftElement>
               <Input
                 type="password"
-                placeholder="비밀번호를 입력하세요"
+                placeholder="영문과 숫자를 포함하여 8자리 이상의 비밀번호를 입력하세요"
                 value={password}
                 onChange={e => setPassword(e.target.value)}
               ></Input>


### PR DESCRIPTION
- 이메일 @gist.ac.kr 로 끝나거나 @gm.gist.ac.kr 로 끝날때만 입력 가능하도록 정규표현식을 이용하여 변경하였습니다.
- 비밀번호는 영문, 숫자를 포함하여 8자리 이상으로 입력하도록 설정하였습니다.
- 모달창을 화면 수직 가운데에 오도록 하였습니다. 

++ 지금은 alert 로 경고를 해주는 방식이지만 submit button의 disabled 속성을 변경하거나 각 인풋에서 미리 경고를 표시하여 
회원가입 버튼을 누르기 전에 미리 입력 오류를 사용자가 확인할 수 있으면 좋을것 같습니다.
