### PR TITLE
Feat/register

### DIFF
--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -38,7 +38,8 @@ const Register = (): JSX.Element => {
 
   const handleCreateCode = async () => {
     const emailRegex = /@(gm.)?gist.ac.kr$/
-    if (!emailRegex.test(input.username)) {
+    if (emailRegex.test(input.username)) {
+      setErrorText('')
       const status = await postCreateVerificationCode({
         username: input.username,
       })
@@ -55,8 +56,14 @@ const Register = (): JSX.Element => {
       username: input.username,
       verificationCode: input.verificationCode,
     })
+    if (status >= 400) {
+      setErrorText('인증 코드가 일치하지 않습니다')
+    } else {
+      setErrorText('')
+    }
     setVerficationStatus(status)
   }
+
   const navigate = useNavigate()
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -91,9 +98,27 @@ const Register = (): JSX.Element => {
                 placeholder="gm.gist 혹은 gist 메일을 입력하세요"
                 value={input.username}
                 onChange={handleChange}
+                disabled={isCodeRequested}
               ></Input>
             </InputGroup>
           </FormControl>
+          {isCodeRequested && (
+            <FormControl isRequired>
+              <Text mb="8px">인증 번호</Text>
+              <InputGroup borderColor="#ccc">
+                <InputLeftElement>
+                  {<CFaLock color="gray.300" />}
+                </InputLeftElement>
+                <Input
+                  type="password"
+                  name="verificationCode"
+                  placeholder="인증코드를 입력하세요"
+                  value={input.verificationCode}
+                  onChange={handleChange}
+                ></Input>
+              </InputGroup>
+            </FormControl>
+          )}
           {verificationStatus < 400 && (
             <FormControl isRequired>
               <Text mb="8px">비밀번호</Text>
@@ -113,7 +138,7 @@ const Register = (): JSX.Element => {
           )}
           {verificationStatus < 400 && (
             <FormControl isRequired>
-              <Text mb="8px">비밀번호확인</Text>
+              <Text mb="8px">비밀번호 확인</Text>
               <InputGroup borderColor="#ccc">
                 <InputLeftElement>
                   {<CFaLock color="gray.300" />}

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -1,5 +1,9 @@
 import React, { FormEvent, useState } from 'react'
-// import { useDispatch } from 'react-redux'
+import {
+  postRegister,
+  postConfirmVerificationCode,
+  postCreateVerificationCode,
+} from '../../utils/api'
 import {
   chakra,
   FormControl,
@@ -16,27 +20,41 @@ const Register = (): JSX.Element => {
   const CFaUserAlt = chakra(FaUserAlt)
   const CFaLock = chakra(FaLock)
 
-  const [user, setUser] = useState<User>({ username: '', password: '' })
-  const [passwordCheck, setPasswordCheck] = useState('')
+  const [input, setInput] = useState<RegisterForm>({
+    username: '',
+    password: '',
+    verificationCode: '',
+    passwordConfirm: '',
+  })
+  const [isCodeRequested, setIsCodeRequested] = useState(false)
+  const [verificationStatus, setVerficationStatus] = useState(500)
+  const [registerStatus, setRegisterStatus] = useState(500)
 
-  const handleChangeUser = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target
-    setUser({ ...user, [name]: value })
+    setInput({ ...input, [name]: value })
   }
-  // const dispatch = useDispatch()
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+
+  const handleCreateCode = async () => {
+    const status = await postCreateVerificationCode({
+      username: input.username,
+    })
+    if (status < 400) {
+      setIsCodeRequested(true)
+    }
+  }
+
+  const handleConfirmCode = async () => {
+    const status = await postConfirmVerificationCode({
+      username: input.username,
+      verificationCode: input.verificationCode,
+    })
+    setVerficationStatus(status)
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    // const emailRegex = /@(gm.)?gist.ac.kr$/
-    // const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
-    // if (!emailRegex.test(email)) {
-    //   alert('이메일 주소를 확인해주세요')
-    // } else if (!passwordRegex.test(password)) {
-    //   alert('영문과 숫자를 포함하여 8자리 이상의 비밀번호를 설정해주세요')
-    // } else if (password !== passwordCheck) {
-    //   alert('비밀번호를 확인해주세요')
-    // }
-    // return
-    // dispatch(registerUserAsync(user))
+    const status = await postRegister(input)
   }
 
   return (
@@ -56,44 +74,53 @@ const Register = (): JSX.Element => {
                 type="email"
                 name="username"
                 placeholder="gm.gist 혹은 gist 메일을 입력하세요"
-                value={user.username}
-                onChange={e => handleChangeUser(e)}
+                value={input.username}
+                onChange={handleChange}
               ></Input>
             </InputGroup>
           </FormControl>
-          <FormControl isRequired>
-            <Text mb="8px">비밀번호</Text>
-            <InputGroup borderColor="#ccc">
-              <InputLeftElement>
-                {<CFaLock color="gray.300" />}
-              </InputLeftElement>
-              <Input
-                type="password"
-                name="password"
-                placeholder="영문과 숫자를 포함하여 8자리 이상의 비밀번호를 입력하세요"
-                value={user.password}
-                onChange={e => handleChangeUser(e)}
-              ></Input>
-            </InputGroup>
-          </FormControl>
-          <FormControl isRequired>
-            <Text mb="8px">비밀번호확인</Text>
-            <InputGroup borderColor="#ccc">
-              <InputLeftElement>
-                {<CFaLock color="gray.300" />}
-              </InputLeftElement>
-              <Input
-                type="password"
-                placeholder="비밀번호를 재 입력하세요"
-                value={passwordCheck}
-                onChange={e => setPasswordCheck(e.target.value)}
-              ></Input>
-            </InputGroup>
-          </FormControl>
-          <RegisterButton type="submit" className="submit__btn">
-            회원가입
-          </RegisterButton>
-
+          {verificationStatus < 400 && (
+            <FormControl isRequired>
+              <Text mb="8px">비밀번호</Text>
+              <InputGroup borderColor="#ccc">
+                <InputLeftElement>
+                  {<CFaLock color="gray.300" />}
+                </InputLeftElement>
+                <Input
+                  type="password"
+                  name="password"
+                  placeholder="영문과 숫자를 포함하여 8자리 이상의 비밀번호를 입력하세요"
+                  value={input.password}
+                  onChange={handleChange}
+                ></Input>
+              </InputGroup>
+            </FormControl>
+          )}
+          {verificationStatus < 400 && (
+            <FormControl isRequired>
+              <Text mb="8px">비밀번호확인</Text>
+              <InputGroup borderColor="#ccc">
+                <InputLeftElement>
+                  {<CFaLock color="gray.300" />}
+                </InputLeftElement>
+                <Input
+                  type="password"
+                  placeholder="비밀번호를 재 입력하세요"
+                  value={input.passwordConfirm}
+                  onChange={handleChange}
+                ></Input>
+              </InputGroup>
+            </FormControl>
+          )}
+          {!isCodeRequested && (
+            <button onClick={handleCreateCode}>인증 번호 전송</button>
+          )}
+          {isCodeRequested && <button onClick={handleConfirmCode}>인증</button>}
+          {verificationStatus < 400 && (
+            <RegisterButton type="submit" className="submit__btn">
+              회원가입
+            </RegisterButton>
+          )}
           <Text mb="4px" align="center">
             이미 가입하셨나요?{' '}
             <a href="/login" style={{ textDecoration: 'underline' }}>

--- a/src/pages/Register/styles.ts
+++ b/src/pages/Register/styles.ts
@@ -17,5 +17,8 @@ const RegisterButton = styled.button`
   height: 36px;
   font-weight: bold;
 `
+const ErrorText = styled.p`
+  color: red;
+`
 
-export { stackStyle, RegisterButton }
+export { stackStyle, RegisterButton, ErrorText }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -2,3 +2,11 @@ interface User {
   username: string
   password: string
 }
+
+interface Register extends User {
+  verificationCode: string
+}
+
+interface RegisterForm extends Register {
+  passwordConfirm: string
+}

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -1,0 +1,6 @@
+export * from './getUsersMe'
+export * from './postConfirmVerificationCode'
+export * from './postCreateVerificationCode'
+export * from './postLogin'
+export * from './postLogout'
+export * from './postRegister'

--- a/src/utils/api/postConfirmVerificationCode.ts
+++ b/src/utils/api/postConfirmVerificationCode.ts
@@ -1,0 +1,9 @@
+import api from './axiosConfigs'
+
+export const postConfirmVerificationCode = async (payload: {
+  username: string
+  verificationCode: string
+}) => {
+  const response = await api.post('username/confirm', payload)
+  return response.status
+}

--- a/src/utils/api/postCreateVerificationCode.ts
+++ b/src/utils/api/postCreateVerificationCode.ts
@@ -1,0 +1,8 @@
+import api from './axiosConfigs'
+
+export const postCreateVerificationCode = async (payload: {
+  username: string
+}) => {
+  const response = await api.post('username/verifications', payload)
+  return response.status
+}

--- a/src/utils/api/postLogin.ts
+++ b/src/utils/api/postLogin.ts
@@ -1,6 +1,6 @@
 import api from './axiosConfigs'
 
-export const postLogin = async (user: User) => {
-  const response = await api.post('login', user)
+export const postLogin = async (payload: User) => {
+  const response = await api.post('login', payload)
   return response.status
 }

--- a/src/utils/api/postRegister.ts
+++ b/src/utils/api/postRegister.ts
@@ -1,6 +1,6 @@
 import api from './axiosConfigs'
 
-export const postLogin = async (user: User) => {
-  const response = await api.post('register', user)
+export const postRegister = async (payload: Register) => {
+  const response = await api.post('users', payload)
   return response.status
 }

--- a/src/utils/checkRegister.ts
+++ b/src/utils/checkRegister.ts
@@ -1,0 +1,11 @@
+const emailRegex = /@(gm.)?gist.ac.kr$/
+const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
+// if (!emailRegex.test(email)) {
+//   alert('이메일 주소를 확인해주세요')
+// } else if (!passwordRegex.test(password)) {
+//   alert('영문과 숫자를 포함하여 8자리 이상의 비밀번호를 설정해주세요')
+// } else if (password !== passwordCheck) {
+//   alert('비밀번호를 확인해주세요')
+// }
+
+export {}


### PR DESCRIPTION
## 개요

회원가입 API 연결

## 미리보기

- 타 이메일 사용시 
![image](https://user-images.githubusercontent.com/63437430/149134770-04619245-c33b-4691-8b71-5977a948b6d0.png)

- 인증 번호 전송 성공 시
![image](https://user-images.githubusercontent.com/63437430/149134847-14630b38-28b0-4253-97d9-bfa5d43def14.png)

- 그 이후는 현재 테스트 진행 불가능


## 상세 설명

일단 기본적으로 코드를 작성하였습니다.
먼저 이메일을 입력하고 인증번호 전송을 합니다.
성공한다면 이메일 인풋을 비활성화하고 인증번호 인증을 진행합니다.
인증에 성공한다면 비밀번호를 입력하고 회원가입을 시도합니다.

## 기타

아직 오류 등 여러가지 상황에 완벽하게 대처하지 못합니다. 추가적으로 작업할 부분은 다음과 같습니다.
- state 관리, 서버로 부터 오는 에러 메세지 관리
- 이메일 중복시 로그인 창으로 이동 (? 이 부분은 저희가 요청시 알 수 있는지 모르겠습니다.)

#60 
