### PR TITLE
feat: reduxjs-toolkit-persist 도입

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-scripts": "^5.0.0",
     "redux": "^4.1.2",
     "redux-logger": "^3.0.6",
+    "reduxjs-toolkit-persist": "^7.0.7",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,17 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { Provider } from 'react-redux'
+import { PersistGate } from 'reduxjs-toolkit-persist/integration/react'
 import App from './App'
 import reportWebVitals from './reportWebVitals'
-import store from './redux/store'
+import { store, persistor } from './redux/store'
 
 ReactDOM.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <PersistGate loading={null} persistor={persistor}>
+        <App />
+      </PersistGate>
     </Provider>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -1,21 +1,43 @@
-import { configureStore } from '@reduxjs/toolkit'
+import {
+  combineReducers,
+  configureStore,
+  getDefaultMiddleware,
+} from '@reduxjs/toolkit'
+import {
+  persistStore,
+  persistReducer,
+  FLUSH,
+  REHYDRATE,
+  PAUSE,
+  PERSIST,
+  PURGE,
+  REGISTER,
+} from 'reduxjs-toolkit-persist'
+import storage from 'reduxjs-toolkit-persist/lib/storage'
 import authReducer from './auth/authSlice'
 
-const store = configureStore({
-  reducer: {
-    auth: authReducer,
-  },
+const reducers = combineReducers({
+  auth: authReducer,
 })
 
-/* HMR
-if (process.env.NODE_ENV === 'development' && module.hot) {
-  module.hot.accept('./rootReducer', () => {
-    const newRootReducer = require('./rootReducer').preventDefault()
-    store.replaceReducer(newRootReducer)
-  })
+const persistConfig = {
+  key: 'root',
+  storage,
 }
-*/
 
-export default store
+const persistedReducer = persistReducer(persistConfig, reducers)
+
+export const store = configureStore({
+  reducer: persistedReducer,
+  middleware: getDefaultMiddleware =>
+    getDefaultMiddleware({
+      serializableCheck: {
+        ignoredActions: [FLUSH, REHYDRATE, PAUSE, PERSIST, PURGE, REGISTER],
+      },
+    }),
+})
+
+export const persistor = persistStore(store)
+
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch

--- a/yarn.lock
+++ b/yarn.lock
@@ -8348,6 +8348,11 @@ redux@^4.0.0, redux@^4.1.2:
   dependencies:
     "@babel/runtime" "^7.9.2"
 
+reduxjs-toolkit-persist@^7.0.7:
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/reduxjs-toolkit-persist/-/reduxjs-toolkit-persist-7.0.7.tgz#0c7365b9a7f26ef4ed9bf61411eec361b8fd5c62"
+  integrity sha512-dWBU/+jT77t2oNU45OgDJPFmNFjkHHfB7q/wDkVnOtL4GUVfZZtYHiP8BwUXFU5N7pM2KC4C/u221eZwUCLqpA==
+
 regenerate-unicode-properties@^9.0.0:
   version "9.0.0"
   resolved "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-9.0.0.tgz"


### PR DESCRIPTION
## 개요

reduxjs-toolkit-persist를 도입하였습니다.

## 상세 설명

새로고침이나 페이지 이동시 redux가 초기화돼서 이를 유지시키기 위해 redux-persist 의 타입스크립트 버전인 reduxjs-toolkit-persist를 도입하였습니다. 

## 기타
- 참고 사항
https://redux-toolkit.js.org/usage/usage-guide#working-with-non-serializable-data
https://www.npmjs.com/package/reduxjs-toolkit-persist

Close #77 
