### PR TITLE
yyyy-mm-dd 시간 형식, 댓글 등록 시간 표시, 글 출력시에도 개행 표시

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+## code changes will send PR to following users
+* @gpgun0 @kimjngyun @leejimin-gist @choi2021

--- a/src/pages/Post/CommentList/index.tsx
+++ b/src/pages/Post/CommentList/index.tsx
@@ -1,5 +1,5 @@
-import { Stack } from '@chakra-ui/react'
-import { CommentItem, CommentAnonymousName } from './styles'
+import { Flex, Stack } from '@chakra-ui/react'
+import { CommentItem, CommentAnonymousName, CommentCreatedAt } from './styles'
 import { getComments } from '../../../utils/api/comment/getComments'
 import { useEffect, useState } from 'react'
 
@@ -25,7 +25,14 @@ const CommentList = ({ postId }: PostId): JSX.Element => {
       {response.map(res => (
         <CommentItem>
           <Stack>
-            <CommentAnonymousName>{res.userId}</CommentAnonymousName>
+            <Flex alignItems={'center'}>
+              <CommentAnonymousName>{res.userId}&nbsp;</CommentAnonymousName>
+              <CommentCreatedAt style={{ fontSize: '12px' }}>
+                {res.createdAt.slice(5, 10) +
+                  '  ' +
+                  res.createdAt.slice(11, 16)}
+              </CommentCreatedAt>
+            </Flex>
             <div>{res.content}</div>
           </Stack>
         </CommentItem>

--- a/src/pages/Post/CommentList/index.tsx
+++ b/src/pages/Post/CommentList/index.tsx
@@ -27,13 +27,15 @@ const CommentList = ({ postId }: PostId): JSX.Element => {
           <Stack>
             <Flex alignItems={'center'}>
               <CommentAnonymousName>{res.userId}&nbsp;</CommentAnonymousName>
-              <CommentCreatedAt style={{ fontSize: '12px' }}>
+              <CommentCreatedAt>
                 {res.createdAt.slice(5, 10) +
                   '  ' +
                   res.createdAt.slice(11, 16)}
               </CommentCreatedAt>
             </Flex>
-            <div>{res.content}</div>
+            <pre>
+              <div>{res.content}</div>
+            </pre>
           </Stack>
         </CommentItem>
       ))}

--- a/src/pages/Post/CommentList/styles.ts
+++ b/src/pages/Post/CommentList/styles.ts
@@ -11,7 +11,7 @@ const CommentAnonymousName = styled.div`
   font-weight: bold;
 `
 const CommentCreatedAt = styled.div`
-  font-size: 14px;
+  font-size: 12px;
   color: #555;
 `
 

--- a/src/pages/Post/CommentList/styles.ts
+++ b/src/pages/Post/CommentList/styles.ts
@@ -10,5 +10,9 @@ const CommentItem = styled.li`
 const CommentAnonymousName = styled.div`
   font-weight: bold;
 `
+const CommentCreatedAt = styled.div`
+  font-size: 14px;
+  color: #555;
+`
 
-export { CommentItem, CommentAnonymousName }
+export { CommentItem, CommentAnonymousName, CommentCreatedAt }

--- a/src/pages/Post/PetitionContents/index.tsx
+++ b/src/pages/Post/PetitionContents/index.tsx
@@ -89,7 +89,9 @@ const PetitionContents = ({ postId }: PostId): JSX.Element => {
           청원내용
         </Text>
         <Divider color={'#ccc'}></Divider>
-        <PetitionDescription>{response.description}</PetitionDescription>
+        <pre>
+          <PetitionDescription>{response.description}</PetitionDescription>
+        </pre>
       </Stack>
       <div>
         <AgreementButton

--- a/src/pages/Post/PetitionContents/index.tsx
+++ b/src/pages/Post/PetitionContents/index.tsx
@@ -69,7 +69,7 @@ const PetitionContents = ({ postId }: PostId): JSX.Element => {
           <Text fontWeight={'bold'} display={'inline-block'}>
             {!response.answered ? '청원진행중' : '답변완료'}&nbsp;
           </Text>
-          <Text display={'inline'}>({response.createdAt}~)</Text>
+          <Text display={'inline'}>({response.createdAt.slice(0, 10)}~)</Text>
         </PetitionProgress>
         <PetitionTitleWrap>
           <PetitionTitle ml={'20px'} mr={'20px'}>

--- a/src/pages/Posts/PetitionList/index.tsx
+++ b/src/pages/Posts/PetitionList/index.tsx
@@ -37,6 +37,7 @@ const PetitionList = (): JSX.Element => {
     getAllPost()
     console.log(query)
   }, [useAppSelect(select => select.query)])
+
   return (
     <>
       <PostsTitle>
@@ -69,7 +70,7 @@ const PetitionList = (): JSX.Element => {
             <PetitionSubject>
               <Link to={`/posts/${post.id}`}>{post.title}</Link>
             </PetitionSubject>
-            <PetitionDate>{post.createdAt}</PetitionDate>
+            <PetitionDate>{post.createdAt.slice(0, 10)}</PetitionDate>
             <PetitionAgreement>{post.agreements.length}</PetitionAgreement>
           </PetitionItem>
         ))}


### PR DESCRIPTION
## 개요

시간 형식을 yyyy-mm-dd 형식으로 보여줍니다. (Desktop 기준)  
댓글 등록시에도 등록 시간을 보여주는데 mm-dd hh:mm 으로 보여줍니다.  

text area 인풋을 받을 때, 개행이 포함돼있으면 출력시에도 이를 적절히 표시해줍니다.

## 미리보기

<img width="876" alt="스크린샷 2022-01-14 오후 3 41 44" src="https://user-images.githubusercontent.com/65757344/149463156-578286f7-eb9e-4cc3-b832-48bfb64ce388.png">

<img width="979" alt="스크린샷 2022-01-14 오후 3 41 19" src="https://user-images.githubusercontent.com/65757344/149463100-4eb2fc7a-827d-4710-a4e3-7c2d1755a405.png">


## 상세 설명

간단하게 slice 함수를 써서 시간 형식을 바꿔주었고 예외 경우를 찾으면 보고해주세요  

개행 표시는 <pre></pre> 태그로 감싸줘서 나타내었습니다.   

## 기타

Close #85 