### PR TITLE
refact: 게시글 필터를 query-string을 이용하는 방식으로 변경

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "framer-motion": "^5.5.5",
     "global": "^4.4.0",
     "jwt-decode": "^3.1.2",
+    "qs": "^6.10.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-icons": "^4.3.1",

--- a/src/pages/Petitions/PaginationButtons/index.tsx
+++ b/src/pages/Petitions/PaginationButtons/index.tsx
@@ -34,13 +34,13 @@ const PaginationButtons = (): JSX.Element => {
       inner: 2,
     },
     initialState: {
-      currentPage: Number(queryParams?.page) || 1,
+      currentPage: Number(queryParams?.page || 1),
     },
   })
 
   useEffect(() => {
     getPaginationInf(queryParams)
-    setCurrentPage(Number(queryParams.page))
+    setCurrentPage(Number(queryParams?.page || 1))
   }, [location.search])
 
   const navigate = useNavigate()

--- a/src/pages/Petitions/PetitionList/index.tsx
+++ b/src/pages/Petitions/PetitionList/index.tsx
@@ -1,5 +1,6 @@
+import qs from 'qs'
 import { ChangeEvent, useEffect, useState } from 'react'
-import { Link, Outlet } from 'react-router-dom'
+import { Link, Outlet, useNavigate } from 'react-router-dom'
 import { setCategory } from '../../../redux/query/querySlice'
 import { useAppDispatch, useAppSelect } from '../../../redux/store.hooks'
 import { Category } from '../../../types/enums'
@@ -15,59 +16,29 @@ import {
   PetitionsDate,
   PetitionsHead,
   PetitionsHeadWrap,
-  PetitionsSelect,
   PetitionsSubject,
-  PetitionsText,
-  PetitionsTitle,
 } from './styles'
 
 const PetitionList = (): JSX.Element => {
-  const numberOfCategory = Object.keys(Category).filter(el =>
-    isNaN(Number(el)),
-  ).length
-
-  const catergoryIdx = Array(numberOfCategory)
-    .fill(0)
-    .map((_x, i) => i)
+  const queryParams: any = qs.parse(location.search, {
+    ignoreQueryPrefix: true,
+  })
 
   const queryPost = async (query: QueryParams) => {
     const status = await getPetitionsByQuery(query)
     if (status[0] < 400) {
-      console.log(status[1].content)
       setPetitionList(status[1].content)
     }
   }
 
-  const [selected, setSelected] = useState(
-    useAppSelect(select => select.query.category),
-  )
-  const [petitionList, setPetitionList] = useState<Array<Petition>>([]) // 수정해야함 api 변경
-  const dispatch = useAppDispatch()
-  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => {
-    setSelected(Number(e.target.value))
-    dispatch(setCategory(Number(e.target.value)))
-  }
-
-  const query = useAppSelect(select => select.query)
+  const [petitionList, setPetitionList] = useState<Array<Petition>>([])
 
   useEffect(() => {
-    console.log(query)
-    queryPost(query)
-  }, [useAppSelect(select => select.query)])
+    queryPost(queryParams)
+  }, [location.search])
 
   return (
     <>
-      <PetitionsTitle>
-        <PetitionsText>모든 청원</PetitionsText>
-        <PetitionsSelect onChange={handleSelect} value={selected} w={'128px'}>
-          {catergoryIdx.map(item => (
-            <option value={item} key={item}>
-              {Category[item]}
-            </option>
-          ))}
-        </PetitionsSelect>
-      </PetitionsTitle>
-
       <PetitionsHead>
         <PetitionsHeadWrap>
           <PetitionsCategory>분류</PetitionsCategory>

--- a/src/pages/Petitions/PetitionList/styles.ts
+++ b/src/pages/Petitions/PetitionList/styles.ts
@@ -1,15 +1,5 @@
 import styled from '@emotion/styled'
-import { Select, Text } from '@chakra-ui/react'
 
-const PetitionsTitle = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: 5px;
-`
-const PetitionsText = styled(Text)`
-  font-size: 20px;
-  font-weight: bold;
-`
 const PetitionsHead = styled.div`
   height: 50px;
   width: 100%;
@@ -47,24 +37,6 @@ const PetitionsAgreement = styled.div`
   width: 90px;
   text-align: center;
 `
-const PetitionsSelect = styled(Select)`
-  width: 128px;
-  height: 40px;
-  border-radius: 0;
-  border-color: #ccc;
-`
-const PetitionItem = styled.li`
-  width: 100%;
-  padding: 20px 0;
-  border-bottom: 1px solid #ddd;
-  :hover {
-    background-color: #f8f8f8;
-  }
-  height: 64px;
-  position: relative;
-  display: flex;
-  align-items: center;
-`
 
 const PetitionCategory = styled.div`
   position: absolute;
@@ -89,10 +61,21 @@ const PetitionAgreement = styled.div`
   color: #df3127;
   font-weight: bold;
 `
+
+const PetitionItem = styled.li`
+  width: 100%;
+  padding: 20px 0;
+  border-bottom: 1px solid #ddd;
+  :hover {
+    background-color: #f8f8f8;
+  }
+  height: 64px;
+  position: relative;
+  display: flex;
+  align-items: center;
+`
+
 export {
-  PetitionsSelect,
-  PetitionsText,
-  PetitionsTitle,
   PetitionsHead,
   PetitionsHeadWrap,
   PetitionsCategory,

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -4,11 +4,52 @@ import { Inner, PetitionBoard } from './styles'
 import { Stack } from '@chakra-ui/react'
 import PetitionList from './PetitionList'
 import PaginationButtons from './PaginationButtons'
+import qs from 'qs'
+import { ChangeEvent, useState } from 'react'
+import { PetitionsSelect, PetitionsText, PetitionsTitle } from './styles'
+import { Category } from '../../types/enums'
+import { useNavigate } from 'react-router-dom'
 
 const Petitions = (): JSX.Element => {
+  const queryParams: any = qs.parse(location.search, {
+    ignoreQueryPrefix: true,
+  })
+
+  const numberOfCategory = Object.keys(Category).filter(el =>
+    isNaN(Number(el)),
+  ).length
+
+  const catergoryIdx = Array(numberOfCategory)
+    .fill(0)
+    .map((_x, i) => i)
+
+  const [selected, setSelected] = useState(queryParams?.category || 0)
+  const navigate = useNavigate()
+  const handleSelect = (e: ChangeEvent<HTMLSelectElement>) => {
+    setSelected(Number(e.target.value))
+    const newSearchParams = {
+      ...queryParams,
+      page: 1,
+      category: Number(e.target.value),
+    }
+    navigate({
+      pathname: '/petitions',
+      search: new URLSearchParams(newSearchParams).toString(),
+    })
+  }
   return (
     <Inner>
       <PetitionBoard>
+        <PetitionsTitle>
+          <PetitionsText>모든 청원</PetitionsText>
+          <PetitionsSelect onChange={handleSelect} value={selected} w={'128px'}>
+            {catergoryIdx.map(item => (
+              <option value={item} key={item}>
+                {Category[item]}
+              </option>
+            ))}
+          </PetitionsSelect>
+        </PetitionsTitle>
         <PetitionList></PetitionList>
         {/* Paigination */}
         <Stack>

--- a/src/pages/Petitions/styles.ts
+++ b/src/pages/Petitions/styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import theme from '../../style/theme'
-
+import { Select, Text } from '@chakra-ui/react'
 const Inner = styled.div`
   position: relative;
   margin: 0 auto;
@@ -13,5 +13,21 @@ const PetitionBoard = styled.div`
   top: 9.375rem;
   text-align: center;
 `
+const PetitionsTitle = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 5px;
+`
 
-export { Inner, PetitionBoard }
+const PetitionsSelect = styled(Select)`
+  width: 128px;
+  height: 40px;
+  border-radius: 0;
+  border-color: #ccc;
+`
+const PetitionsText = styled(Text)`
+  font-size: 20px;
+  font-weight: bold;
+`
+
+export { Inner, PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -15,11 +15,11 @@ import {
 } from 'reduxjs-toolkit-persist'
 import storage from 'reduxjs-toolkit-persist/lib/storage'
 import authReducer from './auth/authSlice'
-import queryReducer from './query/querySlice'
+// import queryReducer from './query/querySlice'
 
 const reducers = combineReducers({
   auth: authReducer,
-  query: queryReducer,
+  // query: queryReducer,
 })
 
 const persistConfig = {

--- a/src/types/petition.d.ts
+++ b/src/types/petition.d.ts
@@ -21,7 +21,7 @@ interface PetitionsInput {
 }
 
 interface QueryParams {
-  size: number
-  page: number
-  category: number
+  size?: number | string
+  page?: number | string
+  category?: number | string
 }

--- a/src/utils/api/petitions/getPetitionsByQuery.ts
+++ b/src/utils/api/petitions/getPetitionsByQuery.ts
@@ -1,10 +1,12 @@
 import api from '../axiosConfigs'
 
 export const getPetitionsByQuery = async (query: QueryParams) => {
+  const size = Number(query?.size) || 10
+  const page = Number(query?.page) || 1
+  const category = Number(query?.category) || 0
+  console.log(size, page, category)
   const response = await api.get(
-    `petitions?size=${query.size}&page=${query.page - 1}&categoryId=${
-      query.category
-    }`,
+    `petitions?size=${size}&page=${page - 1}&categoryId=${category}`,
   )
   return [response.status, response.data]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8026,6 +8026,13 @@ qs@6.9.6:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
+qs@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
+  integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"


### PR DESCRIPTION
## 개요

페이지네이션 구현방식을 변경했습니다.

## 미리보기

![image](https://user-images.githubusercontent.com/63437430/152644939-cad29fab-6b9c-4d09-bace-b8a8bba9f952.png)


## 상세 설명

redux 를 통해 게시글 필터 상태를 저장하는 것 대신에 URI의 쿼리스트링으로 부터 query params를 파싱하여 서버에 게시글 목록을 요청합니다. 
변경 감지는 location.search를 통해 이루어집니다. 

그리고 게시글 목록 상단의 타이틀과 카테고리 선택 부분을 분리하여 메인페이지에서 재사용가능하도록 하였습니다. 

## 기타

Close #123 
Close #116