### PR TITLE
Design/responsive: 모든 청원 페이지네이션 버튼 반응형 및 디테일 수정

### DIFF
--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -12,7 +12,7 @@ const Petition = (): JSX.Element => {
   return (
     <Inner>
       <PetitionWrapper>
-        <PetitionView>
+        <PetitionView p={{ base: '30px 10px', md: '50px 30px' }}>
           <PetitionContents petitionId={castedPetitionId}></PetitionContents>
           <Stack>
             <Text textAlign={'left'} fontWeight={'bold'} fontSize={'20px'}>

--- a/src/pages/Petition/styles.ts
+++ b/src/pages/Petition/styles.ts
@@ -1,3 +1,4 @@
+import { Box } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import theme from '../../style/theme'
 
@@ -16,10 +17,10 @@ const PetitionWrapper = styled.div`
   top: 150px;
 `
 
-const PetitionView = styled.div`
+const PetitionView = styled(Box)`
   width: 100%;
   height: 100%;
-  padding: 50px 35px;
+  /* padding: 50px 35px; */
   text-align: center;
 `
 

--- a/src/pages/Petition/styles.ts
+++ b/src/pages/Petition/styles.ts
@@ -4,8 +4,9 @@ import theme from '../../style/theme'
 const Inner = styled.div`
   position: relative;
   margin: 0 auto;
-  max-width: ${theme.space.innerMaxWidth};
+  max-width: ${theme.space.INNER_MAXWIDTH};
   height: 100%;
+  padding: 0 0.5em;
 `
 
 const PetitionWrapper = styled.div`

--- a/src/pages/Petitions/PaginationButtons/index.tsx
+++ b/src/pages/Petitions/PaginationButtons/index.tsx
@@ -61,32 +61,34 @@ const PaginationButtons = (): JSX.Element => {
       currentPage={currentPage}
       onPageChange={handlePageChange}
     >
-      <PaginationContainer mt="40px">
+      <PaginationContainer
+        mt="40px"
+        flexWrap={{ base: 'wrap', md: 'nowrap' }}
+        justifyContent={{ base: 'space-between', md: 'center' }}
+      >
         <PetitionsPaginationPrevious
+          fontSize={{ base: '12px', md: 'sm' }}
           _focus={{ outline: 'none' }}
           h={{ base: '30px', md: '40px' }}
+          w={{ base: '4rem', md: '5.75rem' }}
         >
           이전
         </PetitionsPaginationPrevious>
         <PetitionsPaginationPageGroup
+          w={{ base: '', md: '100%' }}
           separator={
             <PaginationSeparator
               bg="#fff"
               border="1px solid #ccc"
               borderRadius="0"
               fontSize="sm"
-              w="30px"
+              w={{ base: '22.5px', md: '30px' }}
               h={{ base: '30px', md: '40px' }}
               m={{ base: '0 3px', md: '0 10px' }}
               jumpSize={10}
               _focus={{
                 outline: 'none',
               }}
-              _active={
-                {
-                  // bg: '#2F363C',
-                }
-              }
             />
           }
         >
@@ -97,7 +99,7 @@ const PaginationButtons = (): JSX.Element => {
               bg="#fff"
               border="1px solid #ccc"
               borderRadius="0"
-              fontSize="sm"
+              fontSize={{ base: '12px', md: 'sm' }}
               _hover={{
                 bg: '#2F363C',
                 color: '#fff',
@@ -120,8 +122,10 @@ const PaginationButtons = (): JSX.Element => {
           ))}
         </PetitionsPaginationPageGroup>
         <PetitionsPaginationNext
+          fontSize={{ base: '12px', md: 'sm' }}
           _focus={{ outline: 'none' }}
           h={{ base: '30px', md: '40px' }}
+          w={{ base: '4rem', md: '5.75rem' }}
         >
           다음
         </PetitionsPaginationNext>

--- a/src/pages/Petitions/PaginationButtons/index.tsx
+++ b/src/pages/Petitions/PaginationButtons/index.tsx
@@ -30,7 +30,7 @@ const PaginationButtons = (): JSX.Element => {
   const { currentPage, setCurrentPage, pagesCount, pages } = usePagination({
     pagesCount: totalPages,
     limits: {
-      outer: 2,
+      outer: 1,
       inner: 2,
     },
     initialState: {
@@ -62,7 +62,10 @@ const PaginationButtons = (): JSX.Element => {
       onPageChange={handlePageChange}
     >
       <PaginationContainer mt="40px">
-        <PetitionsPaginationPrevious _focus={{ outline: 'none' }}>
+        <PetitionsPaginationPrevious
+          _focus={{ outline: 'none' }}
+          h={{ base: '30px', md: '40px' }}
+        >
           이전
         </PetitionsPaginationPrevious>
         <PetitionsPaginationPageGroup
@@ -73,6 +76,8 @@ const PaginationButtons = (): JSX.Element => {
               borderRadius="0"
               fontSize="sm"
               w="30px"
+              h={{ base: '30px', md: '40px' }}
+              m={{ base: '0 3px', md: '0 10px' }}
               jumpSize={10}
               _focus={{
                 outline: 'none',
@@ -82,13 +87,13 @@ const PaginationButtons = (): JSX.Element => {
                   // bg: '#2F363C',
                 }
               }
-              m="0 10px"
             />
           }
         >
           {pages.map((page: number) => (
             <PaginationPage
-              w={'40px'}
+              w={{ base: '30px', md: '40px' }}
+              h={{ base: '30px', md: '40px' }}
               bg="#fff"
               border="1px solid #ccc"
               borderRadius="0"
@@ -114,7 +119,10 @@ const PaginationButtons = (): JSX.Element => {
             />
           ))}
         </PetitionsPaginationPageGroup>
-        <PetitionsPaginationNext _focus={{ outline: 'none' }}>
+        <PetitionsPaginationNext
+          _focus={{ outline: 'none' }}
+          h={{ base: '30px', md: '40px' }}
+        >
           다음
         </PetitionsPaginationNext>
       </PaginationContainer>

--- a/src/pages/Petitions/PaginationButtons/styles.ts
+++ b/src/pages/Petitions/PaginationButtons/styles.ts
@@ -8,21 +8,20 @@ import theme from '../../../style/theme'
 import styled from '@emotion/styled'
 
 const PetitionsPaginationPrevious = styled(PaginationPrevious)`
-  background-color: ${theme.color.white};
-  border: 1px solid ${theme.color.ligthGray};
+  background-color: ${theme.color.WHITE};
+  border: 1px solid ${theme.color.LIGHT_GRAY};
   border-radius: 0;
-  width: ${theme.size.paginationWidth}; ;
+  /* width: ${theme.size.PAGINATION_WIDTH}; ; */
 `
 const PetitionsPaginationPageGroup = styled(PaginationPageGroup)`
-  width: 100%;
   justify-content: center;
 `
 
 const PetitionsPaginationNext = styled(PaginationNext)`
-  background-color: ${theme.color.white};
-  border: 1px solid ${theme.color.ligthGray};
+  background-color: ${theme.color.WHITE};
+  border: 1px solid ${theme.color.LIGHT_GRAY};
   border-radius: 0;
-  width: ${theme.size.paginationWidth};
+  /* width: ${theme.size.PAGINATION_WIDTH}; */
 `
 
 export {

--- a/src/pages/Petitions/PetitionList/index.tsx
+++ b/src/pages/Petitions/PetitionList/index.tsx
@@ -56,7 +56,7 @@ const PetitionList = (): JSX.Element => {
               top={{ md: '0' }}
               h={{ md: '16px' }}
               m={{ md: 'auto' }}
-              fontSize={{ base: '14px' }}
+              fontSize={{ base: '14px', md: '16px' }}
             >
               {petition.categoryName}
             </PetitionCategory>

--- a/src/pages/Petitions/PetitionList/index.tsx
+++ b/src/pages/Petitions/PetitionList/index.tsx
@@ -56,6 +56,7 @@ const PetitionList = (): JSX.Element => {
               top={{ md: '0' }}
               h={{ md: '16px' }}
               m={{ md: 'auto' }}
+              fontSize={{ base: '14px' }}
             >
               {petition.categoryName}
             </PetitionCategory>

--- a/src/pages/Petitions/PetitionList/styles.ts
+++ b/src/pages/Petitions/PetitionList/styles.ts
@@ -60,7 +60,6 @@ const PetitionAgreement = styled(Box)`
   position: absolute;
   right: 0;
   color: #df3127;
-  font-weight: bold;
 `
 
 const PetitionItem = styled(ListItem)`


### PR DESCRIPTION
## 개요



## 미리보기


![스크린샷 2022-02-09 오후 2 20 16](https://user-images.githubusercontent.com/65757344/153126833-8386dc38-633c-490c-8de9-95f09da2885d.png)


![스크린샷 2022-02-09 오후 2 19 45](https://user-images.githubusercontent.com/65757344/153126780-24f60c4f-0cbf-476c-bf88-a840d0bedab0.png)


![스크린샷 2022-02-09 오후 2 19 09](https://user-images.githubusercontent.com/65757344/153126743-cb32dadc-c79a-4329-ae45-9d8a2a2df917.png)


## 상세 설명

- 모바일 환경에서 카데고리 글씨 크기 14px로 줄였습니다.
- 모바일 환경에서 청원 게시글 패딩값을 줄였습니다.
- 페이지네이션 바깥 버튼 (separator 바깥) 개수를 1개로 줄였습니다.
- 모바일 환경에서 그림과 같이 버튼 크기를 줄였습니다.

## 기타

Close #141 
