### PR TITLE
Design/responsive: 청원 작성 페이지 반응형 & 로그인 페이지 리팩토링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ const App = (): JSX.Element => {
       <div style={{ minHeight: '100vh' }}>
         <ThemeProvider theme={theme}></ThemeProvider>
         <NavBar />
-        {/* <Footer /> */}
+        <Footer />
         <RootRouter />
       </div>
     </ChakraProvider>

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -47,62 +47,62 @@ const Login = (): JSX.Element => {
   }
   return (
     <>
-      <div className="login">
-        <form className="login__form" onSubmit={handleSubmit}>
-          <Stack spacing={4} style={stackStyle}>
-            <Text fontSize="4xl" fontWeight="bold">
-              로그인
-            </Text>
-            <FormControl isRequired>
-              <Text mb="8px">이메일</Text>
-              <InputGroup borderColor="#ccc">
-                <InputLeftElement pointerEvents="none">
-                  {<CFaUserAlt color="gray.300" />}
-                </InputLeftElement>
-                <Input
-                  type="email"
-                  name="username"
-                  placeholder="이메일을 입력하세요."
-                  value={input.username}
-                  onChange={handleChangeUser}
-                  borderRadius="0"
-                />
-              </InputGroup>
-            </FormControl>
-            <FormControl>
-              <Text mb="8px">비밀번호</Text>
-              <InputGroup borderColor="#ccc">
-                <InputLeftElement pointerEvents="none">
-                  {<CFaLock color="gray.300" />}
-                </InputLeftElement>
-                <Input
-                  type="password"
-                  name="password"
-                  placeholder="비밀번호를 입력하세요."
-                  value={input.password}
-                  onChange={handleChangeUser}
-                  borderRadius="0"
-                />
-              </InputGroup>
-            </FormControl>
-            <ErrorText>{checkLoginError(responseState)}</ErrorText>
-            <Text mb="4px" align="right" decoration="underline">
-              <a href="#">비밀번호를 잊으셨나요?</a>
-            </Text>
+      <form className="login__form" onSubmit={handleSubmit}>
+        {/* <div className="login"> */}
+        <Stack spacing={4} style={stackStyle}>
+          <Text fontSize="4xl" fontWeight="bold">
+            로그인
+          </Text>
+          <FormControl isRequired>
+            <Text mb="8px">이메일</Text>
+            <InputGroup borderColor="#ccc">
+              <InputLeftElement pointerEvents="none">
+                {<CFaUserAlt color="gray.300" />}
+              </InputLeftElement>
+              <Input
+                type="email"
+                name="username"
+                placeholder="이메일을 입력하세요."
+                value={input.username}
+                onChange={handleChangeUser}
+                borderRadius="0"
+              />
+            </InputGroup>
+          </FormControl>
+          <FormControl>
+            <Text mb="8px">비밀번호</Text>
+            <InputGroup borderColor="#ccc">
+              <InputLeftElement pointerEvents="none">
+                {<CFaLock color="gray.300" />}
+              </InputLeftElement>
+              <Input
+                type="password"
+                name="password"
+                placeholder="비밀번호를 입력하세요."
+                value={input.password}
+                onChange={handleChangeUser}
+                borderRadius="0"
+              />
+            </InputGroup>
+          </FormControl>
+          <ErrorText>{checkLoginError(responseState)}</ErrorText>
+          <Text mb="4px" align="right" decoration="underline">
+            <a href="#">비밀번호를 잊으셨나요?</a>
+          </Text>
 
-            <LoginButton type="submit" className="submit__btn">
-              로그인
-            </LoginButton>
+          <LoginButton type="submit" className="submit__btn">
+            로그인
+          </LoginButton>
 
-            <Text mb="4px" align="center">
-              계정이 없으신가요?{' '}
-              <a href="/register" style={{ textDecoration: 'underline' }}>
-                계정 만들기
-              </a>
-            </Text>
-          </Stack>
-        </form>
-      </div>
+          <Text mb="4px" align="center">
+            계정이 없으신가요?{' '}
+            <a href="/register" style={{ textDecoration: 'underline' }}>
+              계정 만들기
+            </a>
+          </Text>
+        </Stack>
+        {/* </div> */}
+      </form>
     </>
   )
 }

--- a/src/pages/Login/styles.ts
+++ b/src/pages/Login/styles.ts
@@ -2,13 +2,11 @@ import styled from '@emotion/styled'
 import theme from '../../style/theme'
 
 const stackStyle: React.CSSProperties = {
-  position: 'absolute',
-  top: '18.75rem',
-  left: '0',
-  right: '0',
-  height: '31.25rem',
-  width: '25rem',
+  height: '100vh',
+  width: '28rem',
   margin: 'auto',
+  justifyContent: 'center',
+  padding: '0 2rem',
 }
 
 const LoginButton = styled.button`

--- a/src/pages/Write/PrecautionModal/index.tsx
+++ b/src/pages/Write/PrecautionModal/index.tsx
@@ -24,7 +24,7 @@ const GuideModal = (): JSX.Element => {
       </ViewWriteMethodButton>
       <Modal isOpen={isOpen} onClose={onClose} size={'xl'}>
         <ModalOverlay />
-        <ModalContent borderRadius={0}>
+        <ModalContent borderRadius={0} m={'auto 2rem'}>
           <ModalHeader m="15px"> GIST 청원, 이렇게 등록하세요</ModalHeader>
           <ModalBody m="0 15px" textAlign={'justify'}>
             <List p="0 12px">

--- a/src/pages/Write/PrecautionModal/styles.ts
+++ b/src/pages/Write/PrecautionModal/styles.ts
@@ -3,7 +3,6 @@ import styled from '@emotion/styled'
 
 const ViewWriteMethodButton = styled(Button)`
   background-color: #2f363c;
-  width: 400px;
   color: white;
   color-scheme: #2f363c;
   border-radius: 2px;

--- a/src/pages/Write/WritePrecaution/index.tsx
+++ b/src/pages/Write/WritePrecaution/index.tsx
@@ -4,11 +4,11 @@ import { StylePrecaution, StyleStrong, PrincipleContents } from './styles'
 const WritePrecaution = (): JSX.Element => {
   return (
     <>
-      <Heading as="h2" fontSize="20px">
+      <Heading fontSize="20px" pl={{ base: 0, sm: '18px' }}>
         GIST 청원 게시판 운영 원칙
       </Heading>
-      <StylePrecaution>
-        <OrderedList spacing={6} mb="30px">
+      <StylePrecaution pl={{ base: 0, sm: '18px' }}>
+        <OrderedList spacing={6} fontSize={{ base: '14px', md: '16px' }}>
           <ListItem>
             <PrincipleContents>
               타인의 권리를 침해하거나 명예를 훼손하는 내용은 제한합니다.

--- a/src/pages/Write/WritePrecaution/index.tsx
+++ b/src/pages/Write/WritePrecaution/index.tsx
@@ -7,7 +7,7 @@ const WritePrecaution = (): JSX.Element => {
       <Heading fontSize="20px" pl={{ base: 0, sm: '18px' }}>
         GIST 청원 게시판 운영 원칙
       </Heading>
-      <StylePrecaution pl={{ base: 0, sm: '18px' }}>
+      <StylePrecaution p={{ base: '18px 0', sm: '18px' }}>
         <OrderedList spacing={6} fontSize={{ base: '14px', md: '16px' }}>
           <ListItem>
             <PrincipleContents>

--- a/src/pages/Write/WritePrecaution/styles.ts
+++ b/src/pages/Write/WritePrecaution/styles.ts
@@ -1,7 +1,9 @@
 import { Box, Container } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 
-const StylePrecaution = styled(Box)``
+const StylePrecaution = styled(Box)`
+  /* padding: 20px; */
+`
 const StyleStrong = styled.span`
   font-weight: bold;
 `

--- a/src/pages/Write/WritePrecaution/styles.ts
+++ b/src/pages/Write/WritePrecaution/styles.ts
@@ -1,19 +1,14 @@
-import { Container } from '@chakra-ui/react'
+import { Box, Container } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 
-const StylePrecaution = styled.div`
-  margin: 30px;
-  padding: 20px;
-`
+const StylePrecaution = styled(Box)``
 const StyleStrong = styled.span`
-  opacity: 1;
-  font-weight: 900;
+  font-weight: bold;
 `
 
 const PrincipleContents = styled(Container)`
-  margin: 0;
-  line-height: 160%;
-  max-width: 85ch;
+  line-height: 1.5rem;
+  max-width: 100%;
   text-align: justify;
 `
 

--- a/src/pages/Write/index.tsx
+++ b/src/pages/Write/index.tsx
@@ -14,27 +14,23 @@ import {
 
 const Write = (): JSX.Element => {
   return (
-    <div>
-      <Inner>
-        <WriteStack spacing={6}>
-          <Heading as="h2" fontSize="20px">
-            청원하기
-          </Heading>
-          <Wrapper>
-            <StyledBoxInner>
-              <Stack m="50px 2px">
-                <WritePrecaution />
-                <GuideModal />
-              </Stack>
-              <Divider color="#ccc" />
-              <StyledPostEditor>
-                <PostEditor />
-              </StyledPostEditor>
-            </StyledBoxInner>
-          </Wrapper>
-        </WriteStack>
-      </Inner>
-    </div>
+    <Inner>
+      <WriteStack spacing={6}>
+        <Heading fontSize="20px">청원하기</Heading>
+        <Wrapper>
+          <StyledBoxInner m={{ base: '1rem', md: '2rem' }}>
+            <Stack m="50px 0">
+              <WritePrecaution />
+              <GuideModal />
+            </Stack>
+            <Divider color="#ccc" m="18px" boxSize={'border-box'} />
+            <StyledPostEditor m={{ base: '60px 0', sm: '60px 18px' }}>
+              <PostEditor />
+            </StyledPostEditor>
+          </StyledBoxInner>
+        </Wrapper>
+      </WriteStack>
+    </Inner>
   )
 }
 

--- a/src/pages/Write/styles.ts
+++ b/src/pages/Write/styles.ts
@@ -1,30 +1,26 @@
 import styled from '@emotion/styled'
+import theme from '../../style/theme'
 import { Box, Stack } from '@chakra-ui/react'
+
 const Inner = styled.div`
   position: relative;
+  max-width: ${theme.space.INNER_MAXWIDTH};
   margin: 0 auto;
-  max-width: 900px;
   height: 100%;
+  padding: 0 2rem;
 `
 
 const WriteStack = styled(Stack)`
-  position: absolute;
-  top: 150px;
-  bottom: 20px;
-  width: 100%;
+  position: relative;
+  top: 9.375rem;
 `
 const Wrapper = styled(Box)`
   border: 1px solid #ccc;
   border-radius: 0;
-  padding: 10px;
   letter-spacing: wide;
 `
 
-const StyledBoxInner = styled.div`
-  margin: 30px;
-`
-const StyledPostEditor = styled.div`
-  margin: 60px 30px;
-`
+const StyledBoxInner = styled(Box)``
+const StyledPostEditor = styled(Box)``
 
 export { Inner, Wrapper, WriteStack, StyledBoxInner, StyledPostEditor }

--- a/src/pages/Write/styles.ts
+++ b/src/pages/Write/styles.ts
@@ -17,7 +17,6 @@ const WriteStack = styled(Stack)`
 const Wrapper = styled(Box)`
   border: 1px solid #ccc;
   border-radius: 0;
-  letter-spacing: wide;
 `
 
 const StyledBoxInner = styled(Box)``


### PR DESCRIPTION
## 개요

청원 작성 페이지 패딩값 조정 및 반응형 작업 마무리 하였습니다.  
또한, 로그인 페이지에서 Footer가 아래 배치될 수 있게끔 리팩토링 하였습니다. 

## 미리보기

<img width="293" alt="스크린샷 2022-02-10 오후 9 38 44" src="https://user-images.githubusercontent.com/65757344/153410199-0db6840f-77d0-4116-9793-e70787a0dfbe.png">

<img width="301" alt="스크린샷 2022-02-10 오후 9 39 57" src="https://user-images.githubusercontent.com/65757344/153410371-a1c46622-3460-4c00-a882-a94857967d96.png">

## 상세 설명


## 기타

Close #이슈\_번호
