### PR TITLE
feat: 답변된 청원, 동의하기 버튼 대신 답변 내용 표시

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ const App = (): JSX.Element => {
       <div style={{ minHeight: '100vh' }}>
         <ThemeProvider theme={theme}></ThemeProvider>
         <NavBar />
-        <Footer />
+        {/* <Footer /> */}
         <RootRouter />
       </div>
     </ChakraProvider>

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -5,6 +5,7 @@ import {
   getPetitionById,
   getStateOfAgreement,
   postAgreePetition,
+  getRetrieveAnswer,
 } from '../../../utils/api'
 import {
   PetitionProgress,
@@ -34,6 +35,13 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
     userId: 0,
   })
   const [isConsented, setIsConsented] = useState<boolean>(false)
+  const [answerContent, setAnswerContent] = useState<AnswerContent>({
+    content: '',
+    createdAt: '',
+    id: 0,
+    petitionId: 0,
+    updatedAt: '',
+  })
   const { onOpen, isOpen, onClose } = useDisclosure()
 
   const handleAgreement = async () => {
@@ -65,6 +73,14 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
       }
     }
     checkAgreeByMe(petitionId)
+  }, [])
+
+  useEffect(() => {
+    const getAnswerContent = async (id: string) => {
+      const getAnswer = await getRetrieveAnswer(id)
+      setAnswerContent(getAnswer?.data)
+    }
+    getAnswerContent(petitionId)
   }, [])
 
   return (
@@ -99,19 +115,34 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
           </ContentWrap>
         </div>
       </Stack>
-      <div>
-        <AgreementButton
-          onClick={handleAgreement}
-          colorScheme={'none'}
-          _focus={{ outline: 'none' }}
-          disabled={isConsented}
-        >
-          <Flex>
-            <CFaFileSignature />
-            <Text>&nbsp;{!isConsented ? '동의하기' : '동의완료'}</Text>
-          </Flex>
-        </AgreementButton>
-      </div>
+      {response.answered ? (
+        <Stack color={'#333'} mt={'20px'} mb={'20px'} spacing={4}>
+          <Text fontSize={'20px'} fontWeight={'bold'} align={'left'}>
+            답변
+          </Text>
+          <Divider color={'#ccc'}></Divider>
+          <div>
+            <ContentWrap>
+              <PetitionDescription>{answerContent.content}</PetitionDescription>
+            </ContentWrap>
+          </div>
+        </Stack>
+      ) : (
+        <div>
+          <AgreementButton
+            onClick={handleAgreement}
+            colorScheme={'none'}
+            _focus={{ outline: 'none' }}
+            disabled={isConsented}
+          >
+            <Flex>
+              <CFaFileSignature />
+              <Text>&nbsp;{!isConsented ? '동의하기' : '동의완료'}</Text>
+            </Flex>
+          </AgreementButton>
+        </div>
+      )}
+
       <NeedLoginModal disclosure={{ isOpen, onClose }}></NeedLoginModal>
     </>
   )

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -35,13 +35,7 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
     userId: 0,
   })
   const [isConsented, setIsConsented] = useState<boolean>(false)
-  const [answerContent, setAnswerContent] = useState<AnswerContent>({
-    content: '',
-    createdAt: '',
-    id: 0,
-    petitionId: 0,
-    updatedAt: '',
-  })
+  const [answerContent, setAnswerContent] = useState<AnswerContent | undefined>()
   const { onOpen, isOpen, onClose } = useDisclosure()
 
   const handleAgreement = async () => {

--- a/src/types/answer.d.ts
+++ b/src/types/answer.d.ts
@@ -1,0 +1,7 @@
+interface AnswerContent {
+  content: string
+  createdAt: string
+  id: number
+  petitionId: number
+  updatedAt: string
+}

--- a/src/utils/api/answer/getRetrieveAnswer.ts
+++ b/src/utils/api/answer/getRetrieveAnswer.ts
@@ -1,0 +1,6 @@
+import api from '../axiosConfigs'
+
+export const getRetrieveAnswer = async (petitionId: string) => {
+  const response = await api.get(`petitions/${petitionId}/answer`)
+  return response
+}

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -1,3 +1,6 @@
+// answer
+export * from './answer/getRetrieveAnswer'
+
 // comment
 export * from './comment/getComments'
 export * from './comment/postCreateComment'


### PR DESCRIPTION
## 개요

답변된 청원은 동의하기 버튼 대신에 답변을 표시해줍니다.  

## 미리보기

<img width="1019" alt="스크린샷 2022-02-11 오전 12 10 45" src="https://user-images.githubusercontent.com/65757344/153436522-82199844-212d-4f27-864c-72edf9b19724.png">


## 상세 설명

코드 작성된 거 재활용하느라 inline으로 적용돼있는데 나중에 한꺼번에 수정하겠습니다  
UI 디자인 작업은 나중에 해보도록 합시다!

## 기타

Close #151 
