### PR TITLE
feat: 청원 작성 후 작성한 게시글로 이동시키기

### DIFF
--- a/src/pages/Write/PostEditor/index.tsx
+++ b/src/pages/Write/PostEditor/index.tsx
@@ -50,16 +50,15 @@ const PostEditor = () => {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    if (petitionInput.title.length > 10) {
-      try {
-        console.log(petitionInput)
-        const petitionsStatus = await postCreatePetition(petitionInput)
-        if (petitionsStatus < 400) {
-          navigate('/')
-        }
-      } catch (error) {
-        console.log(error)
+    try {
+      console.log(petitionInput)
+      const response = await postCreatePetition(petitionInput)
+      if (response) {
+        const url = response?.headers?.location
+        navigate(url)
       }
+    } catch (error) {
+      console.log(error)
     }
   }
 

--- a/src/pages/Write/index.tsx
+++ b/src/pages/Write/index.tsx
@@ -10,8 +10,6 @@ import {
   StyledPostEditor,
 } from './styles'
 
-// 청원글 작성
-
 const Write = (): JSX.Element => {
   return (
     <Inner>

--- a/src/utils/api/petitions/postCreatePetition.ts
+++ b/src/utils/api/petitions/postCreatePetition.ts
@@ -2,5 +2,5 @@ import api from '../axiosConfigs'
 
 export const postCreatePetition = async (payload: PetitionsInput) => {
   const response = await api.post('petitions', payload)
-  return response.status
+  return response
 }


### PR DESCRIPTION
## 개요

청원 작성을 하면 작성한 게시글 페이지로 이동시킵니다.  
이는 사전 동의 기능이 추가되면 유저들에게 더 편리성을 주기 때문에 필요한 기능입니다.  


## 상세 설명

글 작성 POST API 요청을 보내면 response Header안의 Location 값에 주소가 담겨서옵니다.  
navigate의 인수로만 넣어주기만 하면 구현이 됩니다.  

## 기타