### PR TITLE
feat: Comment, Agree API 수정사항 반영

### DIFF
--- a/src/components/PetitionList/index.tsx
+++ b/src/components/PetitionList/index.tsx
@@ -26,6 +26,7 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
     const status = await getPetitions(query)
     if (status[0] < 400) {
       setPetitionList(status[1].content)
+      console.log(status[1].content)
     }
   }
 

--- a/src/pages/Petition/AgreementForm/index.tsx
+++ b/src/pages/Petition/AgreementForm/index.tsx
@@ -1,11 +1,11 @@
 import { Flex, FormControl, useDisclosure } from '@chakra-ui/react'
 import { ChangeEvent, FormEvent, useState, useEffect } from 'react'
 import { getStateOfAgreement, postAgreePetition } from '../../../utils/api'
-import { CommentTextArea, CommentWriteButton } from './styles'
+import { AgreementTextArea, AgreementWriteButton } from './styles'
 import { useNavigate } from 'react-router-dom'
 import NeedLoginModal from '../../../components/NeedLoginModal'
 
-const CommentForm = ({ petitionId }: PetitionId): JSX.Element => {
+const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
   const [input, setInput] = useState<AgreePetition>({
     description: '청원에 동의합니다.',
   })
@@ -50,22 +50,21 @@ const CommentForm = ({ petitionId }: PetitionId): JSX.Element => {
       <form onSubmit={handleSubmit}>
         <FormControl>
           <Flex h="60px">
-            <CommentTextArea
-              placeholder="청원에 동의합니다."
+            <AgreementTextArea
               rows={1}
               _focus={{ outline: 'none' }}
               onChange={handleChange}
             >
               청원에 동의합니다.
-            </CommentTextArea>
-            <CommentWriteButton
+            </AgreementTextArea>
+            <AgreementWriteButton
               _focus={{ outline: 'none' }}
               disabled={isConsented}
               type="submit"
               colorScheme={'none'}
             >
               {!isConsented ? '동의하기' : '동의완료'}
-            </CommentWriteButton>
+            </AgreementWriteButton>
           </Flex>
         </FormControl>
       </form>
@@ -74,4 +73,4 @@ const CommentForm = ({ petitionId }: PetitionId): JSX.Element => {
   )
 }
 
-export default CommentForm
+export default AgreementForm

--- a/src/pages/Petition/AgreementForm/styles.ts
+++ b/src/pages/Petition/AgreementForm/styles.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import { Button, Textarea } from '@chakra-ui/react'
 
-const CommentTextArea = styled(Textarea)`
+const AgreementTextArea = styled(Textarea)`
   border-radius: 0;
   border-color: #ccc;
   font-size: 0.875rem;
@@ -12,7 +12,7 @@ const CommentTextArea = styled(Textarea)`
   }
 `
 
-const CommentWriteButton = styled(Button)`
+const AgreementWriteButton = styled(Button)`
   height: 100%;
   border-radius: 0;
   background-color: #131618;
@@ -22,4 +22,4 @@ const CommentWriteButton = styled(Button)`
   }
 `
 
-export { CommentTextArea, CommentWriteButton }
+export { AgreementTextArea, AgreementWriteButton }

--- a/src/pages/Petition/AgreementList/index.tsx
+++ b/src/pages/Petition/AgreementList/index.tsx
@@ -1,15 +1,14 @@
 import { Flex, Stack } from '@chakra-ui/react'
 import {
-  CommentItem,
-  CommentAnonymousName,
-  CommentCreatedAt,
+  AgreementItem,
+  AgreementAnonymousName,
+  AgreementCreatedAt,
   ContentWrap,
 } from './styles'
-import { getComments } from '../../../utils/api/comment/getComments'
 import { useEffect, useState } from 'react'
-import { getAgreements } from './../../../utils/api/petition/getAgreements'
+import { getAgreements } from '../../../utils/api/petition/getAgreements'
 
-const CommentList = ({ petitionId }: PetitionId): JSX.Element => {
+const AgreementList = ({ petitionId }: PetitionId): JSX.Element => {
   const [response, setResponse] = useState<Array<GetAgreements>>([])
 
   useEffect(() => {
@@ -29,17 +28,19 @@ const CommentList = ({ petitionId }: PetitionId): JSX.Element => {
 
   return (
     <ul>
-      {response.map(res => (
-        <CommentItem key={res.id}>
+      {response.map((res, index) => (
+        <AgreementItem key={res.id}>
           <Stack>
-            <CommentAnonymousName>익명{res.id}</CommentAnonymousName>
+            <AgreementAnonymousName>
+              익명{response.length - index}
+            </AgreementAnonymousName>
             <ContentWrap>
               <div>{res.description}</div>
             </ContentWrap>
           </Stack>
-        </CommentItem>
+        </AgreementItem>
       ))}
     </ul>
   )
 }
-export default CommentList
+export default AgreementList

--- a/src/pages/Petition/AgreementList/styles.ts
+++ b/src/pages/Petition/AgreementList/styles.ts
@@ -1,16 +1,16 @@
 import styled from '@emotion/styled'
 
-const CommentItem = styled.li`
+const AgreementItem = styled.li`
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
   padding: 1em 0.2em;
   margin-top: -1px;
   text-align: left;
 `
-const CommentAnonymousName = styled.div`
+const AgreementAnonymousName = styled.div`
   font-weight: bold;
 `
-const CommentCreatedAt = styled.div`
+const AgreementCreatedAt = styled.div`
   font-size: 0.75rem;
   color: #555;
 `
@@ -18,4 +18,9 @@ const ContentWrap = styled.div`
   white-space: pre-line;
 `
 
-export { CommentItem, CommentAnonymousName, CommentCreatedAt, ContentWrap }
+export {
+  AgreementItem,
+  AgreementAnonymousName,
+  AgreementCreatedAt,
+  ContentWrap,
+}

--- a/src/pages/Petition/CommentForm/index.tsx
+++ b/src/pages/Petition/CommentForm/index.tsx
@@ -1,53 +1,70 @@
 import { Flex, FormControl, useDisclosure } from '@chakra-ui/react'
-import { ChangeEvent, FormEvent, useState } from 'react'
-import { postCreateComment } from '../../../utils/api'
+import { ChangeEvent, FormEvent, useState, useEffect } from 'react'
+import { getStateOfAgreement, postAgreePetition } from '../../../utils/api'
 import { CommentTextArea, CommentWriteButton } from './styles'
 import { useNavigate } from 'react-router-dom'
 import NeedLoginModal from '../../../components/NeedLoginModal'
 
 const CommentForm = ({ petitionId }: PetitionId): JSX.Element => {
-  const [input, setInput] = useState<CommentInput>({
-    content: '',
+  const [input, setInput] = useState<AgreePetition>({
+    description: '청원에 동의합니다.',
   })
-
+  const [isConsented, setIsConsented] = useState<boolean>(false)
   // Register와 Login 페이지와 이름을 통일 시키기 위해
   // onContentChange 에서 handleChange로 이름을 변경합니다.
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-    setInput({ content: e.target.value })
+    setInput({ description: e.target.value })
   }
-
   const navigate = useNavigate()
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     try {
-      const status = await postCreateComment(petitionId, input)
+      const status = await postAgreePetition(petitionId, input)
       if (status === 401) {
         onOpen()
+        console.log('로그인 해야함')
       }
       if (status < 400) {
         console.log(status)
         navigate(0)
+        setIsConsented(true)
       }
     } catch (error) {
       console.log(error)
     }
   }
+  useEffect(() => {
+    const checkAgreeByMe = async (id: string) => {
+      const getStateAgree = await getStateOfAgreement(id)
+      if (getStateAgree[0] < 400) {
+        setIsConsented(getStateAgree[1])
+      }
+    }
+    checkAgreeByMe(petitionId)
+  }, [])
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  postCreateComment
+  postAgreePetition
   return (
     <>
       <form onSubmit={handleSubmit}>
         <FormControl>
           <Flex h="60px">
             <CommentTextArea
-              placeholder="의견을 남겨주세요"
+              placeholder="청원에 동의합니다."
               rows={1}
               _focus={{ outline: 'none' }}
               onChange={handleChange}
-            ></CommentTextArea>
-            <CommentWriteButton _focus={{ outline: 'none' }} type="submit">
-              등록
+            >
+              청원에 동의합니다.
+            </CommentTextArea>
+            <CommentWriteButton
+              _focus={{ outline: 'none' }}
+              disabled={isConsented}
+              type="submit"
+              colorScheme={'none'}
+            >
+              {!isConsented ? '동의하기' : '동의완료'}
             </CommentWriteButton>
           </Flex>
         </FormControl>

--- a/src/pages/Petition/CommentList/index.tsx
+++ b/src/pages/Petition/CommentList/index.tsx
@@ -7,22 +7,24 @@ import {
 } from './styles'
 import { getComments } from '../../../utils/api/comment/getComments'
 import { useEffect, useState } from 'react'
+import { getAgreements } from './../../../utils/api/petition/getAgreements'
 
 const CommentList = ({ petitionId }: PetitionId): JSX.Element => {
-  const [response, setResponse] = useState<Array<CommentResponse>>([])
+  const [response, setResponse] = useState<Array<GetAgreements>>([])
 
   useEffect(() => {
-    const getAllComment = async () => {
+    const getAllAgreements = async () => {
       try {
-        const status = await getComments(petitionId)
+        const status = await getAgreements(petitionId)
         if (status[0] < 400) {
-          setResponse(status[1])
+          setResponse(status[1].content)
+          console.log(status[1].content)
         }
       } catch (error) {
         console.log(error)
       }
     }
-    getAllComment()
+    getAllAgreements()
   }, [])
 
   return (
@@ -30,16 +32,9 @@ const CommentList = ({ petitionId }: PetitionId): JSX.Element => {
       {response.map(res => (
         <CommentItem key={res.id}>
           <Stack>
-            <Flex alignItems={'center'}>
-              <CommentAnonymousName>{res.userId}&nbsp;</CommentAnonymousName>
-              <CommentCreatedAt>
-                {res.createdAt.slice(5, 10) +
-                  '  ' +
-                  res.createdAt.slice(11, 16)}
-              </CommentCreatedAt>
-            </Flex>
+            <CommentAnonymousName>익명{res.id}</CommentAnonymousName>
             <ContentWrap>
-              <div>{res.content}</div>
+              <div>{res.description}</div>
             </ContentWrap>
           </Stack>
         </CommentItem>

--- a/src/pages/Petition/CommentList/styles.ts
+++ b/src/pages/Petition/CommentList/styles.ts
@@ -3,7 +3,7 @@ import styled from '@emotion/styled'
 const CommentItem = styled.li`
   border-top: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
-  padding: 1em 0;
+  padding: 1em 0.2em;
   margin-top: -1px;
   text-align: left;
 `

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -17,10 +17,14 @@ import {
   AgreementButton,
   ContentWrap,
 } from './styles'
+import CommentList from '../CommentList'
+import { useParams } from 'react-router-dom'
+
 const CFaFileSignature = chakra(FaFileSignature)
 
 import { useDisclosure } from '@chakra-ui/react'
 import NeedLoginModal from '../../../components/NeedLoginModal'
+import CommentForm from './../CommentForm/index'
 
 const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
   const [response, setResponse] = useState<Petition>({
@@ -39,17 +43,6 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
     AnswerContent | undefined
   >()
   const { onOpen, isOpen, onClose } = useDisclosure()
-
-  const handleAgreement = async () => {
-    const status = await postAgreePetition(petitionId)
-    if (status === 401) {
-      onOpen()
-      console.log('로그인 해야함')
-    }
-    if (status < 400) {
-      setIsConsented(true)
-    }
-  }
 
   useEffect(() => {
     const getPetitionInformation = async (id: string) => {
@@ -78,7 +71,7 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
     }
     getAnswerContent(petitionId)
   }, [])
-
+  const castedPetitionId = petitionId as string
   return (
     <>
       <Stack spacing={6} color={'#333'}>
@@ -127,17 +120,14 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
         </Stack>
       ) : (
         <div>
-          <AgreementButton
-            onClick={handleAgreement}
-            colorScheme={'none'}
-            _focus={{ outline: 'none' }}
-            disabled={isConsented}
-          >
-            <Flex>
-              <CFaFileSignature />
-              <Text>&nbsp;{!isConsented ? '동의하기' : '동의완료'}</Text>
-            </Flex>
-          </AgreementButton>
+          <Stack>
+            <Text textAlign={'left'} fontWeight={'bold'} fontSize={'20px'}>
+              청원동의{' '}
+              <span style={{ color: '#FF0000' }}>{response.agreements} </span>명
+            </Text>
+            <CommentForm petitionId={castedPetitionId}></CommentForm>
+            <CommentList petitionId={castedPetitionId}></CommentList>
+          </Stack>
         </div>
       )}
 

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -17,14 +17,14 @@ import {
   AgreementButton,
   ContentWrap,
 } from './styles'
-import CommentList from '../CommentList'
+import AgreementList from './../AgreementList'
 import { useParams } from 'react-router-dom'
 
 const CFaFileSignature = chakra(FaFileSignature)
 
 import { useDisclosure } from '@chakra-ui/react'
 import NeedLoginModal from '../../../components/NeedLoginModal'
-import CommentForm from './../CommentForm/index'
+import AgreementForm from './../AgreementForm'
 
 const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
   const [response, setResponse] = useState<Petition>({
@@ -38,7 +38,6 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
     updatedAt: '',
     userId: 0,
   })
-  const [isConsented, setIsConsented] = useState<boolean>(false)
   const [answerContent, setAnswerContent] = useState<
     AnswerContent | undefined
   >()
@@ -52,16 +51,6 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
       }
     }
     getPetitionInformation(petitionId)
-  }, [isConsented])
-
-  useEffect(() => {
-    const checkAgreeByMe = async (id: string) => {
-      const getStateAgree = await getStateOfAgreement(id)
-      if (getStateAgree[0] < 400) {
-        setIsConsented(getStateAgree[1])
-      }
-    }
-    checkAgreeByMe(petitionId)
   }, [])
 
   useEffect(() => {
@@ -121,12 +110,17 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
       ) : (
         <div>
           <Stack>
-            <Text textAlign={'left'} fontWeight={'bold'} fontSize={'20px'}>
+            <Text
+              textAlign={'left'}
+              fontWeight={'bold'}
+              fontSize={'20px'}
+              p={'0.5em 0'}
+            >
               청원동의{' '}
               <span style={{ color: '#FF0000' }}>{response.agreements} </span>명
             </Text>
-            <CommentForm petitionId={castedPetitionId}></CommentForm>
-            <CommentList petitionId={castedPetitionId}></CommentList>
+            <AgreementForm petitionId={castedPetitionId}></AgreementForm>
+            <AgreementList petitionId={castedPetitionId}></AgreementList>
           </Stack>
         </div>
       )}

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -3,8 +3,6 @@ import { useParams } from 'react-router'
 import { Inner, PetitionWrapper, PetitionView } from './styles'
 import { Stack, Text } from '@chakra-ui/react'
 import PetitionContents from './PetitionContents'
-import CommentForm from './CommentForm'
-import CommentList from './CommentList'
 
 const Petition = (): JSX.Element => {
   const { petitionId } = useParams()

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -14,13 +14,6 @@ const Petition = (): JSX.Element => {
       <PetitionWrapper>
         <PetitionView p={{ base: '30px 10px', md: '50px 30px' }}>
           <PetitionContents petitionId={castedPetitionId}></PetitionContents>
-          <Stack>
-            <Text textAlign={'left'} fontWeight={'bold'} fontSize={'20px'}>
-              의견보기
-            </Text>
-            <CommentForm petitionId={castedPetitionId}></CommentForm>
-            <CommentList petitionId={castedPetitionId}></CommentList>
-          </Stack>
         </PetitionView>
       </PetitionWrapper>
     </Inner>

--- a/src/types/petition.d.ts
+++ b/src/types/petition.d.ts
@@ -34,3 +34,12 @@ interface PaginationButton {
   getPetitions: (query: QueryParams) => Promise<any[]>
   pathname: string
 }
+
+interface AgreePetition {
+  description: string
+}
+
+interface GetAgreements {
+  description: string
+  id: number
+}

--- a/src/utils/api/petition/getAgreements.ts
+++ b/src/utils/api/petition/getAgreements.ts
@@ -1,0 +1,6 @@
+import api from '../axiosConfigs'
+
+export const getAgreements = async (petitionId: string) => {
+  const response = await api.get(`petitions/${petitionId}/agreements`)
+  return [response.status, response.data]
+}

--- a/src/utils/api/petition/postAgreePetition.ts
+++ b/src/utils/api/petition/postAgreePetition.ts
@@ -1,6 +1,16 @@
 import api from '../axiosConfigs'
 
-export const postAgreePetition = async (petitionId: string) => {
-  const response = await api.post(`petitions/${petitionId}/agreements`, null)
+export const postAgreePetition = async (
+  petitionId: string,
+  payload: AgreePetition,
+) => {
+  const response = await api.post(`petitions/${petitionId}/agreements`, payload)
   return response.status
 }
+// export const postCreateComment = async (
+//   petitionId: string,
+//   payload: CommentInput,
+// ) => {
+//   const response = await api.post(`petitions/${petitionId}/comments`, payload)
+//   return response.status
+// }


### PR DESCRIPTION
## 개요

Comment, Agree API 수정사항 반영

## 미리보기
### before
![비포](https://user-images.githubusercontent.com/77228503/154103593-531ea948-9f2a-4726-b16c-29dba14dc00e.PNG)
### after
![애프터](https://user-images.githubusercontent.com/77228503/154103552-682ea3b0-f2e7-44c7-80dd-ad2b065799d4.PNG)

## 상세 설명

기존의 comment에 관한 코드를 조금 고쳐서 청원 동의로 바꿨습니다. 
미리보기에서 보이듯이 '청원에 동의합니다'를 기본값으로 넣어두었고, 청원동의가 완료되면 버튼이 비활성되도록 해놨습니다. 
10개까지는 순서대로 청원 동의 댓글이 쌓입니다. 

### 아직 구현 못한 부분
- 10개가 넘어가면 청원 내역이 안 보입니다. pagination을 구현해야합니다.
- 뒤늦게 생각난 것이 청원 버튼 누르면 '주의사항(수정불가에 관한 내용) 경고창'을 구현해줘야 합니다.

## 기타

Close #169
