### PR TITLE
feat: 사전 동의중인 청원

### DIFF
--- a/src/pages/Petition/AgreementForm/index.tsx
+++ b/src/pages/Petition/AgreementForm/index.tsx
@@ -9,9 +9,7 @@ const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
   const [input, setInput] = useState<AgreePetition>({
     description: '청원에 동의합니다.',
   })
-  const [isConsented, setIsConsented] = useState<boolean>(false)
-  // Register와 Login 페이지와 이름을 통일 시키기 위해
-  // onContentChange 에서 handleChange로 이름을 변경합니다.
+  const [isConsented, setIsConsented] = useState(false)
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput({ description: e.target.value })
   }
@@ -20,11 +18,10 @@ const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
     e.preventDefault()
     try {
       const response = await postAgreePetition(petitionId, input)
-      if (response.status === 401) {
+      if (response?.status === 401) {
         onOpen()
         console.log('로그인 해야함')
-      }
-      if (response.status < 400) {
+      } else if (response?.status || 500 < 401) {
         navigate(0)
         setIsConsented(true)
       }
@@ -32,16 +29,22 @@ const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
       console.log(error)
     }
   }
-  useEffect(() => {
-    const checkAgreeByMe = async (id: string) => {
+
+  const checkAgreeByMe = async (id: string) => {
+    try {
       const response = await getStateOfAgreement(id)
       setIsConsented(response?.data)
+    } catch (error) {
+      console.log(error)
     }
+  }
+
+  useEffect(() => {
     checkAgreeByMe(petitionId)
-  }, [])
+  }, [petitionId])
   const { isOpen, onOpen, onClose } = useDisclosure()
 
-  postAgreePetition
+  // postAgreePetition
   return (
     <>
       <form onSubmit={handleSubmit}>

--- a/src/pages/Petition/AgreementForm/index.tsx
+++ b/src/pages/Petition/AgreementForm/index.tsx
@@ -54,9 +54,8 @@ const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
               rows={1}
               _focus={{ outline: 'none' }}
               onChange={handleChange}
-            >
-              청원에 동의합니다.
-            </AgreementTextArea>
+              value="청원에 동의합니다."
+            />
             <AgreementWriteButton
               _focus={{ outline: 'none' }}
               disabled={isConsented}

--- a/src/pages/Petition/AgreementList/index.tsx
+++ b/src/pages/Petition/AgreementList/index.tsx
@@ -8,20 +8,23 @@ import {
 import { useEffect, useState } from 'react'
 import { getAgreements } from '../../../utils/api'
 
-const AgreementList = ({ petitionId }: PetitionId): JSX.Element => {
-  const [response, setResponse] = useState<Array<GetAgreements>>([])
+interface IProps {
+  petitionId: string
+}
 
-  useEffect(() => {
-    const getAllAgreements = async () => {
-      try {
-        const response = await getAgreements(petitionId)
-        setResponse(response?.data?.content)
-      } catch (error) {
-        console.log(error)
-      }
+const AgreementList = ({ petitionId }: IProps): JSX.Element => {
+  const [response, setResponse] = useState<Array<GetAgreements>>([])
+  const getAllAgreements = async () => {
+    try {
+      const response = await getAgreements(petitionId)
+      setResponse(response?.data?.content || [])
+    } catch (error) {
+      console.log(error)
     }
+  }
+  useEffect(() => {
     getAllAgreements()
-  }, [])
+  }, [petitionId])
 
   return (
     <ul>

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -17,68 +17,45 @@ import { useDisclosure } from '@chakra-ui/react'
 import NeedLoginModal from '../../../components/NeedLoginModal'
 import AgreementForm from './../AgreementForm'
 
-const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
-  const [response, setResponse] = useState<Petition>({
-    agreements: 0,
-    answered: true,
-    categoryName: '',
-    createdAt: '',
-    description: '',
-    id: 0,
-    title: '',
-    updatedAt: '',
-    userId: 0,
-  })
+interface IProps {
+  petitionURL: string
+  petitionId: string
+}
+
+const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
+  const [response, setResponse] = useState<Petition | undefined>()
   const [answerContent, setAnswerContent] = useState<
     AnswerContent | undefined
   >()
   const { onOpen, isOpen, onClose } = useDisclosure()
 
   useEffect(() => {
-    const getPetitionInformation = async (id: string) => {
-      const response = await getPetitionById(id)
-      setResponse(
-        response?.data || {
-          agreements: 0,
-          answered: false,
-          categoryName: '',
-          createdAt: '',
-          description: '',
-          id: 0,
-          title: '',
-          updatedAt: '',
-          userId: 0,
-        },
-      )
-    }
-    getPetitionInformation(petitionId)
-  }, [])
-
-  useEffect(() => {
-    const getAnswerContent = async (id: string) => {
-      const getAnswer = await getRetrieveAnswer(id)
+    const getPetitionInformation = async (petitionURL: string) => {
+      const response = await getPetitionById(petitionURL)
+      setResponse(response?.data)
+      const getAnswer = await getRetrieveAnswer(petitionId)
       setAnswerContent(getAnswer?.data)
     }
-    getAnswerContent(petitionId)
-  }, [])
-  const castedPetitionId = petitionId as string
+    getPetitionInformation(petitionURL)
+  }, [petitionId])
+
   return (
     <>
       <Stack spacing={6} color={'#333'}>
         <PetitionProgress>
           <Text fontWeight={'bold'} display={'inline-block'}>
-            {!response.answered ? '청원진행중' : '답변완료'}&nbsp;
+            {!response?.answered ? '청원진행중' : '답변완료'}&nbsp;
           </Text>
-          <Text display={'inline'}>({response.createdAt.slice(0, 10)}~)</Text>
+          <Text display={'inline'}>({response?.createdAt.slice(0, 10)}~)</Text>
         </PetitionProgress>
         <PetitionTitleWrap>
           <PetitionTitle ml={'20px'} mr={'20px'}>
-            {response.title}
+            {response?.title}
           </PetitionTitle>
         </PetitionTitleWrap>
         <CurrentAgreementsText>
           <Text>
-            총 <CurrentAgreements>{response.agreements}</CurrentAgreements>
+            총 <CurrentAgreements>{response?.agreements}</CurrentAgreements>
             명이 동의했습니다.
           </Text>
         </CurrentAgreementsText>
@@ -90,11 +67,11 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
         <Divider color={'#ccc'}></Divider>
         <div>
           <ContentWrap>
-            <PetitionDescription>{response.description}</PetitionDescription>
+            <PetitionDescription>{response?.description}</PetitionDescription>
           </ContentWrap>
         </div>
       </Stack>
-      {response.answered ? (
+      {response?.answered ? (
         <Stack color={'#333'} mt={'20px'} mb={'20px'} spacing={4}>
           <Text fontSize={'20px'} fontWeight={'bold'} align={'left'}>
             답변
@@ -118,10 +95,11 @@ const PetitionContents = ({ petitionId }: PetitionId): JSX.Element => {
               p={'0.5em 0'}
             >
               청원동의{' '}
-              <span style={{ color: '#FF0000' }}>{response.agreements} </span>명
+              <span style={{ color: '#FF0000' }}>{response?.agreements} </span>
+              명
             </Text>
-            <AgreementForm petitionId={castedPetitionId}></AgreementForm>
-            <AgreementList petitionId={castedPetitionId}></AgreementList>
+            <AgreementForm petitionId={petitionId}></AgreementForm>
+            <AgreementList petitionId={petitionId}></AgreementList>
           </Stack>
         </div>
       )}

--- a/src/pages/Petition/PetitionContents/styles.ts
+++ b/src/pages/Petition/PetitionContents/styles.ts
@@ -20,7 +20,7 @@ const CurrentAgreementsText = styled.div`
   font-size: 1.25em;
 `
 
-const CurrentAgreements = styled(Text)`
+const CurrentAgreements = styled.span`
   display: inline;
   color: #df3127;
   font-weight: bold;

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -5,6 +5,8 @@ import PetitionContents from './PetitionContents'
 
 const Petition = (): JSX.Element => {
   const { petitionId } = useParams()
+  console.log(location.pathname)
+  console.log(petitionId)
   const castedPetitionId = petitionId as string
   return (
     <Inner>

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -2,17 +2,32 @@
 import { useParams } from 'react-router'
 import { Inner, PetitionWrapper, PetitionView } from './styles'
 import PetitionContents from './PetitionContents'
+import { getPetitionById } from '../../utils/api'
+import { useEffect, useState } from 'react'
+import AgreementForm from './AgreementForm'
+import AgreementList from './AgreementList'
 
 const Petition = (): JSX.Element => {
-  const { petitionId } = useParams()
-  console.log(location.pathname)
-  console.log(petitionId)
-  const castedPetitionId = petitionId as string
+  const { id } = useParams()
+  const [petitionId, setPetitionId] = useState<string>(String(id))
+  const petitionURL: string = location.pathname.slice(1)
+  const getPetitionId = async (petitionURL: string) => {
+    const response = await getPetitionById(petitionURL)
+    if (response?.data?.id) {
+      setPetitionId(String(response?.data?.id))
+    }
+  }
+  useEffect(() => {
+    getPetitionId(petitionURL)
+  }, [])
   return (
     <Inner>
       <PetitionWrapper>
         <PetitionView p={{ base: '30px 10px', md: '50px 30px' }}>
-          <PetitionContents petitionId={castedPetitionId}></PetitionContents>
+          <PetitionContents
+            petitionURL={petitionURL}
+            petitionId={petitionId}
+          ></PetitionContents>
         </PetitionView>
       </PetitionWrapper>
     </Inner>

--- a/src/route/RootRouter.tsx
+++ b/src/route/RootRouter.tsx
@@ -28,7 +28,7 @@ const RootRouter = (): JSX.Element => {
           <Route path=":petitionId" element={<Petition />} />
         </Route>
         <Route path="/petitions/temp" element={<Outlet />}>
-          <Route path=":petitionId" element={<Petition />} />
+          <Route path=":id" element={<Petition />} />
         </Route>
         <Route path="/mypetitions" element={<AuthRoute />}>
           <Route index element={<MyPetitions />} />

--- a/src/route/RootRouter.tsx
+++ b/src/route/RootRouter.tsx
@@ -27,6 +27,9 @@ const RootRouter = (): JSX.Element => {
           <Route index element={<Petitions />} />
           <Route path=":petitionId" element={<Petition />} />
         </Route>
+        <Route path="/petitions/temp" element={<Outlet />}>
+          <Route path=":petitionId" element={<Petition />} />
+        </Route>
         <Route path="/mypetitions" element={<AuthRoute />}>
           <Route index element={<MyPetitions />} />
         </Route>

--- a/src/utils/api/answer/getRetrieveAnswer.ts
+++ b/src/utils/api/answer/getRetrieveAnswer.ts
@@ -1,6 +1,7 @@
 import api from '../axiosConfigs'
 
 export const getRetrieveAnswer = async (petitionId: string) => {
+  if (petitionId.length === 6 || petitionId === 'undefined') return
   const response = await api.get(`petitions/${petitionId}/answer`)
   return response
 }

--- a/src/utils/api/comment/getComments.ts
+++ b/src/utils/api/comment/getComments.ts
@@ -1,6 +1,0 @@
-import api from '../axiosConfigs'
-
-export const getComments = async (petitionId: string) => {
-  const response = await api.get(`petitions/${petitionId}/comments`)
-  return [response.status, response.data]
-}

--- a/src/utils/api/comment/postCreateComment.ts
+++ b/src/utils/api/comment/postCreateComment.ts
@@ -1,9 +1,0 @@
-import api from '../axiosConfigs'
-
-export const postCreateComment = async (
-  petitionId: string,
-  payload: CommentInput,
-) => {
-  const response = await api.post(`petitions/${petitionId}/comments`, payload)
-  return response.status
-}

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -1,10 +1,6 @@
 // answer
 export * from './answer/getRetrieveAnswer'
 
-// comment
-export * from './comment/getComments'
-export * from './comment/postCreateComment'
-
 // petitions
 export * from './petition/getPetitionById'
 export * from './petition/getPetitionCount'

--- a/src/utils/api/petition/getAgreementCount.ts
+++ b/src/utils/api/petition/getAgreementCount.ts
@@ -1,6 +1,7 @@
 import api from '../axiosConfigs'
 
 export const getAgreementCount = async (petitionId: string) => {
+  if (petitionId.length === 6 || petitionId === 'undefined') return
   const response = await api.get(`petitions/${petitionId}/agreements`)
   return response
 }

--- a/src/utils/api/petition/getAgreements.ts
+++ b/src/utils/api/petition/getAgreements.ts
@@ -1,6 +1,7 @@
 import api from '../axiosConfigs'
 
 export const getAgreements = async (petitionId: string) => {
+  if (petitionId.length === 6 || petitionId === 'undefined') return
   const response = await api.get(`petitions/${petitionId}/agreements`)
   return response
 }

--- a/src/utils/api/petition/getPetitionById.ts
+++ b/src/utils/api/petition/getPetitionById.ts
@@ -1,6 +1,6 @@
 import api from '../axiosConfigs'
 
 export const getPetitionById = async (petitionId: string) => {
-  const response = await api.get(`petitions/${petitionId}`)
+  const response = await api.get(petitionId)
   return response
 }

--- a/src/utils/api/petition/getStateOfAgreement.ts
+++ b/src/utils/api/petition/getStateOfAgreement.ts
@@ -1,6 +1,7 @@
 import api from '../axiosConfigs'
 
 export const getStateOfAgreement = async (petitionId: string) => {
+  if (petitionId.length === 6 || petitionId === 'undefined') return
   const response = await api.get(`petitions/${petitionId}/agreements/me`)
   return response
 }

--- a/src/utils/api/petition/postAgreePetition.ts
+++ b/src/utils/api/petition/postAgreePetition.ts
@@ -4,6 +4,7 @@ export const postAgreePetition = async (
   petitionId: string,
   payload: AgreePetition,
 ) => {
+  if (petitionId.length === 6 || petitionId === 'undefined') return
   const response = await api.post(`petitions/${petitionId}/agreements`, payload)
   return response
 }


### PR DESCRIPTION
## 개요

임시 청원을 처리하는 로직을 반영하기 위해 Petition 컴포넌트와 관련 API 를 수정하였습니다.

## 미리보기

<img width="1377" alt="image" src="https://user-images.githubusercontent.com/63437430/154318372-bb12db61-7bed-4636-8ce6-1be4965f3bb6.png">


## 상세 설명

임시 청원은 `/petitions/temp/Du3r20` 같은 형식으로 확인할 수 있습니다. 청원은 생성될때 tempURL 칼럼을 가지며 이 값을 헤더의 Location 을 통해서 알려줍니다. 그리고 원래 저희가 사용하던 id 값도 여전히 가져올 수 있습니다. 

사전동의중인 청원의 정보는 이 tempURL 주소를 통해 접근할 수 있고 해당 청원에 연결된 정보인 agreements 나 answer 조회는 여전히 id를 이용합니다.

따라서 Petition 컴포넌트에서 전달해주던 Props인 petitionId를 가지고는 사전 청원과 연결되어있는 정보를 가져올 수 없는 문제가 있었습니다.

이를 해결하기 위해 Peition/index.tsx에서 먼저 `location.pathname`을 통해 청원 정보를 확인할 url을 가져오고 이 값을 통해 getPeitionById 요청을 보냅니다. 

해당 요청의 response에서 청원의 id를 가져오고 이 값을 다시 petitionId state에 넣어줍니다. 

하위 컴포넌트에서는 useEffect 안에 petitionId를 구독하여 다시끔 API를 호출하도록 합니다.

추가적으로 tempURL으로 기존의 API를 호출하게되면 (Long 타입이 아닌경우) 500 에러를 반환하기 때문에 API 요청 함수에서 petitionId를 한번 검증하고 요청을 보내도록하여 불필요한 호출을 줄여주었는데 이 부분의 로직이 깔끔하지 않다고 생각합니다.

제가 생각한 방법은 tempURL의 길이가 6이고, undefined 일때 바로 return을 해주었는데 더 좋은 방법이 있을지 논의해보면 좋을듯합니다. 

Link #181 
