### PR TITLE
design: footer 패딩값 적용 & Inner를 Component로 분리

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,11 +1,12 @@
 import logo from '../../assets/img/footer_logo.png'
-import { FooterContainer, Inner, Logo, Text } from './styles'
+import { FooterContainer, Text } from './styles'
+import Inner from '../Inner'
 
 const Footer = (): JSX.Element => {
   return (
     <FooterContainer>
       <Inner>
-        <Logo alt="Logo" src={logo}></Logo>
+        <img alt="Logo" src={logo}></img>
         <Text>
           <span>
             (61005) 광주광역시 북구 첨단과기로 123(오룡동) TEL: 062-715-2074 /

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -1,30 +1,34 @@
 import styled from '@emotion/styled'
-
 import theme from '../../style/theme'
 
 const FooterContainer = styled.footer`
   height: 4rem;
   background-color: ${theme.color.WHITE};
   width: 100%;
+  .inner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
+  img {
+    margin-right: 1em;
+    height: 1.5rem;
+    width: auto;
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      height: 2rem;
+    }
+  }
 `
 
-const Inner = styled.div`
-  height: 100%;
-  margin: 0 auto;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`
-
-const Logo = styled.img`
-  margin-right: 1em;
-  height: 1.5rem;
-  width: auto;
-  @media screen and (min-width: ${theme.breakpoints.md}) {
-    height: 2rem;
-  } ;
-`
+// const Inner = styled.div`
+//   height: 100%;
+//   margin: 0 auto;
+//   max-width: ${theme.space.INNER_MAXWIDTH};
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   padding: 0 2rem;
+// `
 
 const Text = styled.p`
   font-size: 0.6rem;
@@ -35,4 +39,4 @@ const Text = styled.p`
   } ;
 `
 
-export { FooterContainer, Inner, Logo, Text }
+export { FooterContainer, Text }

--- a/src/components/Inner/index.tsx
+++ b/src/components/Inner/index.tsx
@@ -1,0 +1,8 @@
+import { FC } from 'react'
+import { StyledInner } from './styles'
+
+const Inner: FC = ({ children }): JSX.Element => {
+  return <StyledInner className="inner">{children}</StyledInner>
+}
+
+export default Inner

--- a/src/components/Inner/styles.ts
+++ b/src/components/Inner/styles.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled'
+import theme from '../../style/theme'
+
+const StyledInner = styled.div`
+  position: relative;
+  height: 100%;
+  margin: 0 auto;
+  max-width: ${theme.space.INNER_MAXWIDTH};
+  padding: 0 ${theme.space.INNER_PADDING};
+`
+
+export { StyledInner }

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -1,10 +1,11 @@
 import logo from '../../assets/img/new_logo.svg'
 import { ReactComponent as MobMenuIcon } from '../../assets/img/menu_icon.svg'
-import { Header, Inner, Logo, TopMenu, ItemName, MobMenuButton } from './styles'
+import { Header, Logo, TopMenu, ItemName, MobMenuButton } from './styles'
 import { useState } from 'react'
-import { Divider, List, ListItem } from '@chakra-ui/react'
+import { Divider, ListItem } from '@chakra-ui/react'
 import MyMenu from './MyMenu'
 import { Link } from 'react-router-dom'
+import Inner from '../Inner'
 
 const NavBar = (): JSX.Element => {
   const [opened, setOpened] = useState<boolean>(false)
@@ -16,7 +17,7 @@ const NavBar = (): JSX.Element => {
 
   return (
     <Header>
-      <Inner flexDirection={{ base: 'column', md: 'row' }}>
+      <Inner>
         <Logo>
           <Link to="/" onClick={closeMenu}>
             <img alt="logo" src={logo} />

--- a/src/components/NavBar/styles.ts
+++ b/src/components/NavBar/styles.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled'
 import theme from '../../style/theme'
-import { Box, Button, List } from '@chakra-ui/react'
+import { Button, List } from '@chakra-ui/react'
 
 const Header = styled.header`
   height: 3.75rem;
@@ -10,17 +10,17 @@ const Header = styled.header`
   z-index: 1000;
   background-color: rgba(47, 54, 60, 0.9);
   //#384046, rgba로 opacity를 먹여야 children 요소가 투명해지지 않습니다.
-`
-const Inner = styled(Box)`
-  position: relative;
-  margin: 0 auto;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  @media screen and (min-width: ${theme.breakpoints.md}) {
-    padding: 0 2rem;
+  .inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    flex-direction: column;
+    padding: 0;
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      padding: 0 ${theme.space.INNER_PADDING};
+      flex-direction: row;
+    }
   }
 `
 
@@ -89,4 +89,4 @@ const MobMenuButton = styled(Button)`
   transform: ${props => (props.open ? 'rotate(-90deg)' : 'none')};
 `
 
-export { Header, Inner, Logo, TopMenu, ItemName, MobMenuButton }
+export { Header, Logo, TopMenu, ItemName, MobMenuButton }

--- a/src/components/PetitionList/styles.ts
+++ b/src/components/PetitionList/styles.ts
@@ -2,6 +2,8 @@ import { Box, ListItem } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 
 const PetitionsHead = styled(Box)`
+  text-align: center;
+
   height: 50px;
   width: 100%;
   border-bottom: 1px solid #ddd;

--- a/src/pages/AnsweredPetitions/index.tsx
+++ b/src/pages/AnsweredPetitions/index.tsx
@@ -1,4 +1,4 @@
-import { Inner, PetitionBoard } from './styles'
+import { PetitionBoard } from './styles'
 import { Stack } from '@chakra-ui/react'
 import { PetitionsText, PetitionsTitle } from './styles'
 import PaginationButtons from '../../components/PaginationButtons'
@@ -8,6 +8,8 @@ import qs from 'qs'
 import { ChangeEvent, useState } from 'react'
 import { Category } from '../../types/enums'
 import { useNavigate } from 'react-router-dom'
+
+import Inner from '../../components/Inner'
 
 const AnsweredPetitions = (): JSX.Element => {
   const queryParams: any = qs.parse(location.search, {

--- a/src/pages/AnsweredPetitions/styles.ts
+++ b/src/pages/AnsweredPetitions/styles.ts
@@ -1,13 +1,5 @@
 import styled from '@emotion/styled'
-import theme from '../../style/theme'
 import { Box, Select, Text } from '@chakra-ui/react'
-const Inner = styled.div`
-  position: relative;
-  margin: 0 auto;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  height: 100%;
-  padding: 0 2em;
-`
 
 const PetitionBoard = styled.div`
   position: relative;
@@ -35,4 +27,4 @@ const PetitionsText = styled(Text)`
   margin-bottom: 1px;
 `
 
-export { Inner, PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }
+export { PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,7 +1,6 @@
 import MainPrecaution from './MainPrecaution'
 import {
   InnerWrap,
-  Inner,
   DashBoard,
   MainBackgroundImage,
   SloganFirstRow,
@@ -11,6 +10,7 @@ import { useEffect, useState } from 'react'
 import { getPetitionCount } from '../../utils/api'
 import PetitionList from '../../components/PetitionList'
 import { getPetitionsByQuery } from '../../utils/api'
+import Inner from '../../components/Inner'
 
 const Home = (): JSX.Element => {
   const [petitionCount, setPetitionCount] = useState(0)

--- a/src/pages/Home/styles.ts
+++ b/src/pages/Home/styles.ts
@@ -18,14 +18,6 @@ const InnerWrap = styled(Box)`
   backdrop-filter: blur(2px);
   height: 100%;
 `
-const Inner = styled(Box)`
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  position: relative;
-  margin: 0 auto;
-  height: 100%;
-  padding: 0 2rem;
-  text-align: center;
-`
 
 const DashBoard = styled(Box)`
   position: absolute;
@@ -80,7 +72,6 @@ const SloganSecondRow = styled.span`
 export {
   MainBackgroundImage,
   InnerWrap,
-  Inner,
   DashBoard,
   SloganFirstRow,
   SloganSecondRow,

--- a/src/pages/MyPetitions/index.tsx
+++ b/src/pages/MyPetitions/index.tsx
@@ -1,4 +1,4 @@
-import { Inner, PetitionBoard } from './styles'
+import { PetitionBoard } from './styles'
 import { Stack } from '@chakra-ui/react'
 import { PetitionsText, PetitionsTitle } from './styles'
 import PaginationButtons from '../../components/PaginationButtons'
@@ -8,6 +8,7 @@ import qs from 'qs'
 import { ChangeEvent, useState } from 'react'
 import { Category } from '../../types/enums'
 import { useNavigate } from 'react-router-dom'
+import Inner from '../../components/Inner'
 
 const MyPetitions = (): JSX.Element => {
   const queryParams: any = qs.parse(location.search, {

--- a/src/pages/MyPetitions/styles.ts
+++ b/src/pages/MyPetitions/styles.ts
@@ -1,13 +1,5 @@
 import styled from '@emotion/styled'
-import theme from '../../style/theme'
 import { Box, Select, Text } from '@chakra-ui/react'
-const Inner = styled.div`
-  position: relative;
-  margin: 0 auto;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  height: 100%;
-  padding: 0 2em;
-`
 
 const PetitionBoard = styled.div`
   position: relative;
@@ -35,4 +27,4 @@ const PetitionsText = styled(Text)`
   margin-bottom: 1px;
 `
 
-export { Inner, PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }
+export { PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }

--- a/src/pages/Petition/AgreementList/index.tsx
+++ b/src/pages/Petition/AgreementList/index.tsx
@@ -1,10 +1,5 @@
-import { Flex, Stack } from '@chakra-ui/react'
-import {
-  AgreementItem,
-  AgreementAnonymousName,
-  AgreementCreatedAt,
-  ContentWrap,
-} from './styles'
+import { Stack } from '@chakra-ui/react'
+import { AgreementItem, AgreementAnonymousName, ContentWrap } from './styles'
 import { useEffect, useState } from 'react'
 import { getAgreements } from '../../../utils/api'
 

--- a/src/pages/Petition/PetitionContents/styles.ts
+++ b/src/pages/Petition/PetitionContents/styles.ts
@@ -3,6 +3,7 @@ import { Button, Text } from '@chakra-ui/react'
 
 const PetitionProgress = styled.div`
   font-size: 1.25rem;
+  text-align: center;
 `
 
 const PetitionTitleWrap = styled.div`

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -1,11 +1,12 @@
 // 청원 Id로 해당 글, 글 좋아요, 댓글 조회
 import { useParams } from 'react-router'
-import { Inner, PetitionWrapper, PetitionView, SharingPetition } from './styles'
+import { Container, PetitionWrapper, SharingPetition } from './styles'
 import PetitionContents from './PetitionContents'
 import { getPetitionById } from '../../utils/api'
 import { useEffect, useState } from 'react'
 import { RiKakaoTalkFill, RiFacebookFill } from 'react-icons/ri'
 import { IoMdAlbums } from 'react-icons/io'
+import Inner from '../../components/Inner'
 
 const Petition = (): JSX.Element => {
   const { id } = useParams()
@@ -60,66 +61,66 @@ const Petition = (): JSX.Element => {
   }
 
   return (
-    <Inner>
-      <PetitionWrapper>
-        <PetitionView p={{ base: '30px 10px', md: '50px 30px' }}>
+    <Container>
+      <Inner>
+        <PetitionWrapper>
           <PetitionContents
             petitionURL={petitionURL}
             petitionId={petitionId}
           ></PetitionContents>
-        </PetitionView>
-      </PetitionWrapper>
-      <SharingPetition>
-        <div className="share-url">
-          <div className="url-box">
-            <div>URL</div>
-            <div className="url">
-              https://dev.gist-petition.com/
-              {petitionURL}
+        </PetitionWrapper>
+        <SharingPetition>
+          <div className="share-url">
+            <div className="url-box">
+              <div>URL</div>
+              <div className="url">
+                https://dev.gist-petition.com/
+                {petitionURL}
+              </div>
+            </div>
+            <div className="copy-btn">
+              <button onClick={clip}>
+                <IoMdAlbums />
+              </button>
             </div>
           </div>
-          <div className="copy-btn">
-            <button onClick={clip}>
-              <IoMdAlbums />
-            </button>
+          <div className="share-btns">
+            <div>공유하기</div>
+            <ul className="sns">
+              <li className="kakaotalk">
+                <a
+                  href="#n"
+                  id="btnKakao"
+                  onClick={() => {
+                    fn_sendFB('kakaotalk')
+                    return false
+                  }}
+                  className="kakaotalk"
+                  target="_self"
+                  title="카카오톡 새창열림"
+                >
+                  <RiKakaoTalkFill />
+                </a>
+              </li>
+              <li className="facebook">
+                <a
+                  href="#n"
+                  onClick={() => {
+                    fn_sendFB('facebook')
+                    return false
+                  }}
+                  className="facebook"
+                  target="_self"
+                  title="페이스북 새창열림"
+                >
+                  <RiFacebookFill />
+                </a>
+              </li>
+            </ul>
           </div>
-        </div>
-        <div className="share-btns">
-          <div>공유하기</div>
-          <ul className="sns">
-            <li className="kakaotalk">
-              <a
-                href="#n"
-                id="btnKakao"
-                onClick={() => {
-                  fn_sendFB('kakaotalk')
-                  return false
-                }}
-                className="kakaotalk"
-                target="_self"
-                title="카카오톡 새창열림"
-              >
-                <RiKakaoTalkFill />
-              </a>
-            </li>
-            <li className="facebook">
-              <a
-                href="#n"
-                onClick={() => {
-                  fn_sendFB('facebook')
-                  return false
-                }}
-                className="facebook"
-                target="_self"
-                title="페이스북 새창열림"
-              >
-                <RiFacebookFill />
-              </a>
-            </li>
-          </ul>
-        </div>
-      </SharingPetition>
-    </Inner>
+        </SharingPetition>
+      </Inner>
+    </Container>
   )
 }
 

--- a/src/pages/Petition/styles.ts
+++ b/src/pages/Petition/styles.ts
@@ -1,26 +1,19 @@
-import { Box } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import theme from '../../style/theme'
 
-const Inner = styled.div`
-  position: relative;
-  margin: 0 auto;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  height: 100%;
-  padding: 0 0.5em;
+const Container = styled.div`
+  .inner {
+    padding: 0 0.5rem;
+  }
 `
-
 const PetitionWrapper = styled.div`
-  display: flex;
   border: 1px solid #ccc;
   position: relative;
   margin: 150px 0 50px 0;
-`
-
-const PetitionView = styled(Box)`
-  width: 100%;
-  height: 100%;
-  text-align: center;
+  padding: 30px 10px;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    padding: 50px 30px;
+  }
 `
 
 const SharingPetition = styled.div`
@@ -125,4 +118,4 @@ const SharingPetition = styled.div`
   }
 `
 
-export { Inner, PetitionWrapper, PetitionView, SharingPetition }
+export { Container, PetitionWrapper, SharingPetition }

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -1,13 +1,13 @@
-import { Inner, PetitionBoard } from './styles'
-import { Stack } from '@chakra-ui/react'
+import { Select, Stack } from '@chakra-ui/react'
 import PetitionList from '../../components/PetitionList'
 import PaginationButtons from '../../components/PaginationButtons'
 import qs from 'qs'
 import { ChangeEvent, useState } from 'react'
-import { PetitionsSelect, PetitionsText, PetitionsTitle } from './styles'
+import { Container, PetitionBoard } from './styles'
 import { Category } from '../../types/enums'
 import { useNavigate } from 'react-router-dom'
 import { getPetitionsByQuery } from '../../utils/api'
+import Inner from '../../components/Inner'
 
 const Petitions = (): JSX.Element => {
   const queryParams: any = qs.parse(location.search, {
@@ -37,27 +37,29 @@ const Petitions = (): JSX.Element => {
     })
   }
   return (
-    <Inner>
-      <PetitionBoard>
-        <PetitionsTitle>
-          <PetitionsText>모든 청원</PetitionsText>
-          <PetitionsSelect onChange={handleSelect} value={selected} w={'128px'}>
-            {catergoryIdx.map(item => (
-              <option value={item} key={item}>
-                {Category[item]}
-              </option>
-            ))}
-          </PetitionsSelect>
-        </PetitionsTitle>
-        <PetitionList getPetitions={getPetitionsByQuery}></PetitionList>
-        <Stack>
-          <PaginationButtons
-            getPetitions={getPetitionsByQuery}
-            pathname={'/petitions'}
-          />
-        </Stack>
-      </PetitionBoard>
-    </Inner>
+    <Container>
+      <Inner>
+        <PetitionBoard>
+          <div className="petition_type">
+            <span>모든 청원</span>
+            <Select onChange={handleSelect} value={selected} w={'128px'}>
+              {catergoryIdx.map(item => (
+                <option value={item} key={item}>
+                  {Category[item]}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <PetitionList getPetitions={getPetitionsByQuery}></PetitionList>
+          <Stack>
+            <PaginationButtons
+              getPetitions={getPetitionsByQuery}
+              pathname={'/petitions'}
+            />
+          </Stack>
+        </PetitionBoard>
+      </Inner>
+    </Container>
   )
 }
 

--- a/src/pages/Petitions/styles.ts
+++ b/src/pages/Petitions/styles.ts
@@ -1,37 +1,27 @@
 import styled from '@emotion/styled'
-import theme from '../../style/theme'
-import { Box, Select, Text } from '@chakra-ui/react'
-const Inner = styled.div`
-  position: relative;
-  margin: 0 auto;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  height: 100%;
-  padding: 0 2em;
-`
+
+const Container = styled.div``
 
 const PetitionBoard = styled.div`
   position: relative;
-  /* top: 9.375rem; */
   margin-top: 9.375rem;
   text-align: center;
-`
-const PetitionsTitle = styled(Box)`
-  display: flex;
-  justify-content: space-between;
-  padding-bottom: 5px;
-  border-bottom: 2px solid #333;
-`
-
-const PetitionsSelect = styled(Select)`
-  width: 128px;
-  height: 40px;
-  border-radius: 0;
-  border-color: #ccc;
-`
-
-const PetitionsText = styled(Text)`
-  font-size: 20px;
-  font-weight: bold;
+  .petition_type {
+    display: flex;
+    justify-content: space-between;
+    padding-bottom: 5px;
+    border-bottom: 2px solid #333;
+    span {
+      font-size: 20px;
+      font-weight: bold;
+    }
+  }
+  .chakra-select {
+    width: 128px;
+    height: 40px;
+    border-radius: 0;
+    border-color: #ccc;
+  }
 `
 
-export { Inner, PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }
+export { Container, PetitionBoard }

--- a/src/pages/Write/index.tsx
+++ b/src/pages/Write/index.tsx
@@ -1,35 +1,31 @@
 import WritePrecaution from './WritePrecaution'
 import GuideModal from './GuideModal'
-import { Heading, Stack, Divider } from '@chakra-ui/react'
 import PostEditor from './PostEditor'
-import {
-  Inner,
-  WriteStack,
-  Wrapper,
-  StyledBoxInner,
-  StyledPostEditor,
-} from './styles'
-import { useEffect } from 'react'
+import { Heading, Stack, Divider, Box } from '@chakra-ui/react'
+import { Container, WriteWrapper } from './styles'
+import Inner from '../../components/Inner'
 
 const Write = (): JSX.Element => {
   return (
-    <Inner>
-      <WriteStack spacing={6}>
-        <Heading fontSize="20px">청원하기</Heading>
-        <Wrapper>
-          <StyledBoxInner m={{ base: '1rem', md: '2rem' }}>
-            <Stack m="50px 0">
-              <WritePrecaution />
-              <GuideModal />
-            </Stack>
-            <Divider color="#ccc" m="18px" boxSize={'border-box'} />
-            <StyledPostEditor m={{ base: '60px 0', sm: '60px 18px' }}>
-              <PostEditor />
-            </StyledPostEditor>
-          </StyledBoxInner>
-        </Wrapper>
-      </WriteStack>
-    </Inner>
+    <Container>
+      <Inner>
+        <Stack spacing={6}>
+          <Heading fontSize="20px">청원하기</Heading>
+          <WriteWrapper>
+            <Box m={{ base: '1rem', md: '2rem' }}>
+              <Stack m="50px 0">
+                <WritePrecaution />
+                <GuideModal />
+              </Stack>
+              <Divider color="#ccc" m="18px" boxSize={'border-box'} />
+              <Box m={{ base: '60px 0', sm: '60px 18px' }}>
+                <PostEditor />
+              </Box>
+            </Box>
+          </WriteWrapper>
+        </Stack>
+      </Inner>
+    </Container>
   )
 }
 

--- a/src/pages/Write/styles.ts
+++ b/src/pages/Write/styles.ts
@@ -1,25 +1,16 @@
 import styled from '@emotion/styled'
-import theme from '../../style/theme'
-import { Box, Stack } from '@chakra-ui/react'
+// import theme from '../../style/theme'
+import { Box } from '@chakra-ui/react'
 
-const Inner = styled.div`
-  position: relative;
-  max-width: ${theme.space.INNER_MAXWIDTH};
-  margin: 0 auto;
-  height: 100%;
-  padding: 0 2rem;
+const Container = styled.div`
+  .inner > .chakra-stack {
+    position: relative;
+    margin: 9.375rem 0;
+  }
 `
-
-const WriteStack = styled(Stack)`
-  position: relative;
-  margin: 9.375rem 0;
-`
-const Wrapper = styled(Box)`
+const WriteWrapper = styled(Box)`
   border: 1px solid #ccc;
   border-radius: 0;
 `
 
-const StyledBoxInner = styled(Box)``
-const StyledPostEditor = styled(Box)``
-
-export { Inner, Wrapper, WriteStack, StyledBoxInner, StyledPostEditor }
+export { Container, WriteWrapper }

--- a/src/pages/Write/styles.ts
+++ b/src/pages/Write/styles.ts
@@ -3,9 +3,12 @@ import styled from '@emotion/styled'
 import { Box } from '@chakra-ui/react'
 
 const Container = styled.div`
-  .inner > .chakra-stack {
-    position: relative;
-    margin: 9.375rem 0;
+  .inner {
+    padding: 0 0.5rem;
+    > .chakra-stack {
+      position: relative;
+      margin: 9.375rem 0;
+    }
   }
 `
 const WriteWrapper = styled(Box)`

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -25,6 +25,7 @@ const size = {
 
 const space = {
   INNER_MAXWIDTH: '60rem',
+  INNER_PADDING: '2rem',
   BUTTON_INNER_MAXWIDTH: '60rem',
 }
 


### PR DESCRIPTION
## 개요

footer에 패딩값을 적용하였으며 Inner를 컴포넌트로 따로 빼두었습니다.  

그리고 Inner가 쓰인 페이지를 수정하면서 Emotion 태그의 복잡도를 낮췄습니다.  

## 상세 설명

```jsx
import { FC } from 'react'
import { StyledInner } from './styles'

const Inner: FC = ({ children }): JSX.Element => {
  return <StyledInner className="inner">{children}</StyledInner>
}

export default Inner
```

```jsx
import styled from '@emotion/styled'
import theme from '../../style/theme'

const StyledInner = styled.div`
  position: relative;
  height: 100%;
  margin: 0 auto;
  max-width: ${theme.space.INNER_MAXWIDTH};
  padding: 0 ${theme.space.INNER_PADDING};
`

export { StyledInner }
```

Inner의 디폴트 값입니다.  

만약 Inner를 불러왔는데 추가적인 속성을 넣어야 한다면  
StyledInner 태그에 있는 inner 클래스명을 활용하면 됩니다.  

예시는 다음과 같습니다.  



NavBar의 styles.ts 파일
```js
const Header = styled.header`

  // ...

  .inner {
    display: flex;
    align-items: center;
    justify-content: space-between;

    flex-direction: column;
    padding: 0;
    @media screen and (min-width: ${theme.breakpoints.md}) {
      padding: 0 ${theme.space.INNER_PADDING};
      flex-direction: row;
    }
  }
```` 


## 기타

Close #192 
