### PR TITLE
feat: 비밀번호 찾기 페이지 추가

### DIFF
--- a/src/pages/FindingPassword/index.tsx
+++ b/src/pages/FindingPassword/index.tsx
@@ -1,0 +1,310 @@
+import React, { FormEvent, useRef, useState } from 'react'
+import {
+  chakra,
+  FormControl,
+  InputGroup,
+  InputLeftElement,
+  Stack,
+  Text,
+  Input,
+  Spinner,
+  Flex,
+  useToast,
+} from '@chakra-ui/react'
+import theme from '../../style/theme'
+import { FaUserAlt, FaLock } from 'react-icons/fa'
+import { RegisterButton, stackStyle, ErrorText } from './styles'
+import { useNavigate } from 'react-router-dom'
+import { useDispatch, useSelector } from 'react-redux'
+import { RootState } from '../../redux/store'
+import { postConfirmVerificationCodeForPassword } from '../../utils/api/findPassword/postConfirmVerificationCodeForPassword'
+import { postCreateVerificationCodeForPassword } from '../../utils/api/findPassword/postCreateVerificationCodeForPassword'
+import { putResetPassword } from '../../utils/api/findPassword/putResetPassword'
+import { setFindPasswordWhichInfo } from '../../redux/findPassword/findPasswordSlice'
+
+const FindingPassword = (): JSX.Element => {
+  const CFaUserAlt = chakra(FaUserAlt)
+  const CFaLock = chakra(FaLock)
+  const navigate = useNavigate()
+  const emailRef = useRef<HTMLInputElement>(null)
+  const verificationRef = useRef<HTMLInputElement>(null)
+  const passwordRef = useRef<HTMLInputElement>(null)
+  const [input, setInput] = useState<RegisterForm>({
+    username: '',
+    password: '',
+    verificationCode: '',
+    passwordConfirm: '',
+  })
+  const whichUI = useSelector((state: RootState) => state.findPassword)
+  const dispatch = useDispatch()
+  const toast = useToast({
+    variant: 'toast',
+  })
+  const [errorText, setErrorText] = useState('')
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target
+    if (name === 'verificationCode') {
+      if (value.length > 6) {
+        return
+      }
+      setInput({ ...input, [name]: value.toUpperCase() })
+      return
+    }
+    setInput({ ...input, [name]: value })
+  }
+
+  const handleCreateCode = async () => {
+    const emailRegex = /@(gm.)?gist.ac.kr$/
+    if (!emailRegex.test(input.username)) {
+      setErrorText('지스트 메일을 이용해주세요')
+      return
+    }
+    dispatch(setFindPasswordWhichInfo('Loading'))
+    const response = await postCreateVerificationCodeForPassword({
+      username: input.username,
+    })
+    const status = response?.status
+    const message = response?.data.message
+    setErrorText(message)
+    if (status > 400) {
+      setInput({ ...input, username: '' })
+      emailRef.current && emailRef.current.focus()
+      dispatch(setFindPasswordWhichInfo('Loading'))
+    } else if (status < 400) {
+      dispatch(setFindPasswordWhichInfo('Loading'))
+      dispatch(setFindPasswordWhichInfo('CodeRequested'))
+      setErrorText(`${input.username}으로 인증 코드가 전송되었습니다`)
+    }
+  }
+
+  const handleConfirmCode = async () => {
+    const response = await postConfirmVerificationCodeForPassword({
+      username: input.username,
+      verificationCode: input.verificationCode,
+    })
+    console.log(response)
+    const status = response?.status
+    const message = response?.data.message
+    if (status < 400) {
+      dispatch(setFindPasswordWhichInfo('Verificated'))
+      dispatch(setFindPasswordWhichInfo('Valid'))
+      return
+    }
+    switch (message) {
+      case '존재하지 않는 인증 정보입니다.': {
+        setInput({ ...input, verificationCode: '' })
+        verificationRef.current && verificationRef.current.focus()
+        break
+      }
+      case '만료된 인증 코드입니다.': {
+        setInput({ ...input, verificationCode: '' })
+        dispatch(setFindPasswordWhichInfo('Expired'))
+        break
+      }
+      case undefined: {
+        throw Error('API 호출에 실패했습니다')
+      }
+    }
+    setErrorText(message)
+  }
+
+  const handleResendCode = async () => {
+    dispatch(setFindPasswordWhichInfo('Loading'))
+    setErrorText('')
+    const response = await postCreateVerificationCodeForPassword({
+      username: input.username,
+    })
+    const status = response.status
+    if (status < 400) {
+      dispatch(setFindPasswordWhichInfo('Expired'))
+      dispatch(setFindPasswordWhichInfo('Loading'))
+      setErrorText(`${input.username}으로 인증 코드가 전송되었습니다`)
+    }
+  }
+
+  const handleReset = async () => {
+    setErrorText('')
+    const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
+    if (!passwordRegex.test(input.password)) {
+      setErrorText('영문과 숫자를 포함한 8자리 이상의 비밀번호를 설정해주세요')
+      return
+    }
+    if (input.password === input.passwordConfirm) {
+      const response = await putResetPassword({
+        password: input.password,
+        username: input.username,
+        verificationCode: input.verificationCode,
+      })
+      const status = response.status
+      const message = response.data.message
+      setErrorText(message)
+
+      if (status < 400) {
+        toast({
+          status: 'success',
+          duration: 3000,
+          description: '비밀번호 재설정',
+          title: '비밀번호가 재설정되었습니다',
+          isClosable: true,
+        })
+        navigate('/login')
+      } else {
+        dispatch(setFindPasswordWhichInfo('Valid'))
+      }
+    } else {
+      passwordRef.current && passwordRef.current.focus()
+      setErrorText('비밀번호가 일치하지 않습니다')
+    }
+  }
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+  }
+
+  const handleReverify = () => {
+    setInput({
+      ...input,
+      verificationCode: '',
+      password: '',
+      passwordConfirm: '',
+    })
+    setErrorText('')
+    dispatch(setFindPasswordWhichInfo('Verificated'))
+    dispatch(setFindPasswordWhichInfo('CodeRequested'))
+  }
+
+  return (
+    <section className="register">
+      <form onSubmit={handleSubmit} className="register__form">
+        <Stack spacing={4} style={stackStyle}>
+          <Text fontSize="4xl" fontWeight="bold">
+            비밀번호 찾기
+          </Text>
+          <FormControl isRequired>
+            <Text mb="8px">이메일</Text>
+            <InputGroup borderColor={`${theme.color.ligthGray}`}>
+              <InputLeftElement>
+                {<CFaUserAlt color="gray.300" />}
+              </InputLeftElement>
+              <Input
+                ref={emailRef}
+                type="email"
+                name="username"
+                placeholder="지스트 메일을 입력하세요"
+                value={input.username}
+                onChange={handleChange}
+                disabled={whichUI.isCodeRequested}
+                borderRadius="0"
+              ></Input>
+            </InputGroup>
+          </FormControl>
+
+          {whichUI.isCodeRequested && !whichUI.isExpired && (
+            <FormControl isRequired>
+              <Text mb="8px">인증 코드</Text>
+              <InputGroup borderColor={`${theme.color.ligthGray}`}>
+                <InputLeftElement>
+                  {<CFaLock color="gray.300" />}
+                </InputLeftElement>
+                <Input
+                  ref={verificationRef}
+                  type="text"
+                  name="verificationCode"
+                  placeholder="이메일로 온 인증 코드를 입력하세요"
+                  value={input.verificationCode}
+                  onChange={handleChange}
+                  disabled={whichUI.isVerificated}
+                  style={{ textTransform: 'uppercase' }}
+                  borderRadius="0"
+                ></Input>
+              </InputGroup>
+            </FormControl>
+          )}
+          {whichUI.isVerificated && (
+            <FormControl isRequired>
+              <Text mb="8px">비밀번호</Text>
+              <InputGroup borderColor={`${theme.color.ligthGray}`}>
+                <InputLeftElement>
+                  {<CFaLock color="gray.300" />}
+                </InputLeftElement>
+                <Input
+                  ref={passwordRef}
+                  type="password"
+                  name="password"
+                  placeholder="영문과 숫자를 포함한 8자리 이상의 비밀번호를 입력하세요"
+                  value={input.password}
+                  onChange={handleChange}
+                  borderRadius="0"
+                ></Input>
+              </InputGroup>
+            </FormControl>
+          )}
+          {whichUI.isVerificated && (
+            <FormControl isRequired>
+              <Text mb="8px">비밀번호 확인</Text>
+              <InputGroup borderColor={`${theme.color.ligthGray}`}>
+                <InputLeftElement>
+                  {<CFaLock color="gray.300" />}
+                </InputLeftElement>
+                <Input
+                  type="password"
+                  name="passwordConfirm"
+                  placeholder="비밀번호를 재입력하세요"
+                  value={input.passwordConfirm}
+                  onChange={handleChange}
+                  borderRadius="0"
+                ></Input>
+              </InputGroup>
+            </FormControl>
+          )}
+          {!whichUI.isCodeRequested &&
+            !whichUI.isLoading &&
+            !whichUI.isExpired && (
+              <RegisterButton onClick={handleCreateCode}>
+                인증 코드 전송
+              </RegisterButton>
+            )}
+          {whichUI.isExpired && (
+            <RegisterButton onClick={handleResendCode}>
+              인증코드 재전송
+            </RegisterButton>
+          )}
+
+          {whichUI.isLoading && (
+            <Flex flexDirection="column" alignItems="center">
+              <Spinner
+                m="auto"
+                thickness="4px"
+                speed="0.65s"
+                emptyColor="gray.200"
+                color="#df3127"
+                size="xl"
+                mb="10px"
+              />
+              잠시만 기다려주세요...
+            </Flex>
+          )}
+
+          {whichUI.isCodeRequested &&
+            !whichUI.isVerificated &&
+            !whichUI.isExpired && (
+              <RegisterButton onClick={handleConfirmCode}>인증</RegisterButton>
+            )}
+          {!whichUI.isExpired && whichUI.isVerificated && !whichUI.isValid && (
+            <RegisterButton onClick={handleReverify}>
+              다시 인증하기
+            </RegisterButton>
+          )}
+          {whichUI.isVerificated && whichUI.isValid && (
+            <RegisterButton onClick={handleReset} className="submit__btn">
+              비밀번호 재설정
+            </RegisterButton>
+          )}
+          <ErrorText>{errorText}</ErrorText>
+        </Stack>
+      </form>
+    </section>
+  )
+}
+
+export default FindingPassword

--- a/src/pages/FindingPassword/styles.ts
+++ b/src/pages/FindingPassword/styles.ts
@@ -1,0 +1,38 @@
+import styled from '@emotion/styled'
+import theme from '../../style/theme'
+
+const stackStyle: React.CSSProperties = {
+  position: 'absolute',
+  top: '10rem',
+  left: '0',
+  right: '0',
+  height: '31.25rem',
+  width: '25rem',
+  margin: 'auto',
+}
+
+const RegisterButton = styled.button`
+  color: ${theme.color.WHITE};
+  background-color: ${theme.color.TERTIARY_GRAY};
+  border-radius: 0.1rem;
+  height: 2.25rem;
+  font-weight: bold;
+`
+
+const ErrorText = styled.p`
+  text-align: center;
+  color: ${theme.color.PRIMARY_RED};
+`
+const DeleteBtn = styled.button`
+  position: absolute;
+  top: 1em;
+  right: 0;
+  width: 10%;
+  color: ${theme.color.WHITE};
+  background-color: ${theme.color.TERTIARY_GRAY};
+  border-radius: 0.1rem;
+  height: 2.25rem;
+  font-weight: bold;
+`
+
+export { stackStyle, RegisterButton, ErrorText, DeleteBtn }

--- a/src/redux/findPassword/findPasswordSlice.ts
+++ b/src/redux/findPassword/findPasswordSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice } from '@reduxjs/toolkit'
+const initialState: FindPasswordWhichUI = {
+  isCodeRequested: false,
+  isLoading: false,
+  isExpired: false,
+  isVerificated: false,
+  isValid: false,
+}
+
+export const findPasswordSlice = createSlice({
+  name: 'findPassword',
+  initialState,
+  reducers: {
+    setFindPasswordWhichInfo: (state, action) => {
+      console.log(action.payload)
+      switch (action.payload) {
+        case 'CodeRequested':
+          state.isCodeRequested = !state.isCodeRequested
+          break
+        case 'Loading':
+          state.isLoading = !state.isLoading
+          break
+        case 'Expired':
+          state.isExpired = !state.isExpired
+          break
+        case 'Verificated':
+          state.isVerificated = !state.isVerificated
+          break
+        case 'Valid':
+          state.isValid = !state.isValid
+          break
+        default:
+          throw new Error('You sent a wrong action')
+      }
+    },
+  },
+})
+
+export const { setFindPasswordWhichInfo } = findPasswordSlice.actions
+export default findPasswordSlice.reducer

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -12,18 +12,21 @@ import {
 import storage from 'reduxjs-toolkit-persist/lib/storage'
 import authReducer from './auth/authSlice'
 import registerSlice from './register/registerSlice'
+import findPasswordSlice from './findPassword/findPasswordSlice'
+
 // import queryReducer from './query/querySlice'
 
 const reducers = combineReducers({
   auth: authReducer,
   register: registerSlice,
+  findPassword: findPasswordSlice,
   // query: queryReducer,
 })
 
 const persistConfig = {
   key: 'root',
   storage,
-  blacklist: ['register'],
+  blacklist: ['register', 'findPassword'],
 }
 
 const persistedReducer = persistReducer(persistConfig, reducers)

--- a/src/route/RootRouter.tsx
+++ b/src/route/RootRouter.tsx
@@ -9,6 +9,7 @@ import Write from '../pages/Write'
 import MyPetitions from '../pages/MyPetitions'
 import AnsweredPetitions from '../pages/AnsweredPetitions'
 import { AuthRoute, UnauthRoute } from './PrivateRouter'
+import FindingPassword from '../pages/FindingPassword'
 import NavBar from '../components/NavBar'
 
 const RootRouter = (): JSX.Element => {
@@ -36,6 +37,7 @@ const RootRouter = (): JSX.Element => {
         <Route path="/mypetitions" element={<AuthRoute />}>
           <Route index element={<MyPetitions />} />
         </Route>
+        <Route path="/findpassword" element={<FindingPassword />}></Route>
         <Route path="/answer" element={<Outlet />}>
           <Route index element={<AnsweredPetitions />} />
         </Route>

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -40,3 +40,12 @@ interface AgreeAttribute {
   isClicked: boolean
 }
 // 회원 가입 UI 관련
+
+interface FindPasswordWhichUI {
+  isCodeRequested: boolean
+  isLoading: boolean
+  isExpired: boolean
+  isVerificated: boolean
+  isValid: boolean
+}
+// 비밀번호찾기 UI 관련

--- a/src/utils/api/findPassword/postConfirmVerificationCodeForPassword.ts
+++ b/src/utils/api/findPassword/postConfirmVerificationCodeForPassword.ts
@@ -1,0 +1,9 @@
+import api from '../axiosConfigs'
+
+export const postConfirmVerificationCodeForPassword = async (payload: {
+  username: string
+  verificationCode: string
+}) => {
+  const response = await api.post('find-password/confirm', payload)
+  return response
+}

--- a/src/utils/api/findPassword/postCreateVerificationCodeForPassword.ts
+++ b/src/utils/api/findPassword/postCreateVerificationCodeForPassword.ts
@@ -1,0 +1,8 @@
+import api from '../axiosConfigs'
+
+export const postCreateVerificationCodeForPassword = async (payload: {
+  username: string
+}) => {
+  const response = await api.post('find-password/verifications', payload)
+  return response
+}

--- a/src/utils/api/findPassword/putResetPassword.ts
+++ b/src/utils/api/findPassword/putResetPassword.ts
@@ -1,0 +1,10 @@
+import api from '../axiosConfigs'
+
+export const putResetPassword = async (payload: {
+  password: string
+  username: string
+  verificationCode: string
+}) => {
+  const response = await api.put('users/reset-password', payload)
+  return response
+}

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -22,3 +22,8 @@ export * from './user/getUsersMe'
 // verfication
 export * from './verification/postConfirmVerificationCode'
 export * from './verification/postCreateVerificationCode'
+
+// findPassword
+export * from './findPassword/postConfirmVerificationCodeForPassword'
+export * from './findPassword/postCreateVerificationCodeForPassword'
+export * from './findPassword/putResetPassword'


### PR DESCRIPTION
## 개요

비밀번호 찾기 페이지를 추가합니다.
branch를 전에 pr날렸던곳에서 다시 파서 작업되어서 오류가 생겼어서 다시 pr날립니다.

## 미리보기

![image](https://user-images.githubusercontent.com/80830981/154853798-65fd518b-db33-4cc5-8aff-350323c353f4.png)

![image](https://user-images.githubusercontent.com/80830981/154853815-11db0d88-6aeb-4885-bfc1-1ca5ed4e4d2e.png)

![image](https://user-images.githubusercontent.com/80830981/154853827-e14c31eb-fd7e-4a26-a976-38d4c250e2c9.png)


## 상세 설명
전반적으로 회원가입페이지와 유사한 구성으로 만들었습니다
1. 로그인페이지에서 비밀번호찾기를 누르면 "/findpassword" url과 연결해두었습니다.
2. 이메일로 인증코드를 발송하고 승인되면 비밀번호를 재설정하게 하는 flow를 위해 api들을 연결해두었습니다.
3. state는 회원가입페이지와 같이 redux로 관리했습니다.
4. 비밀번호 재설정 완료시 다시 로그인 페이지로 넘어갑니다.
## 기타

Close #208 
