### PR TITLE
fix/warning: NotFound 워닝 & 로그인 400에러 해결

### DIFF
--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -23,7 +23,7 @@ const Login = (): JSX.Element => {
   const CFaUserAlt = chakra(FaUserAlt)
   const CFaLock = chakra(FaLock)
 
-  const [input, setInput] = useState<User>({ userEmail: '', userPwd: '' })
+  const [input, setInput] = useState<User>({ username: '', password: '' })
   const [responseState, setResponseState] = useState<number>(0)
 
   const [viewPassword, setViewPassword] = useState<boolean>(false)
@@ -84,8 +84,8 @@ const Login = (): JSX.Element => {
               <Input
                 ref={email}
                 type="email"
-                name="userEmail"
-                id="userEmail"
+                name="username"
+                id="uesrname"
                 placeholder="이메일을 입력하세요."
                 // value={input.userEmail}
                 // onChange={handleChangeUser}
@@ -129,8 +129,8 @@ const Login = (): JSX.Element => {
             className="login_btn"
             onClick={() => {
               setInput({
-                userEmail: email.current && email.current.value,
-                userPwd: pwd.current && pwd.current.value,
+                username: email.current ? email.current.value : '',
+                password: pwd.current ? pwd.current.value : '',
               })
             }}
           >

--- a/src/pages/NotFound/index.tsx
+++ b/src/pages/NotFound/index.tsx
@@ -1,7 +1,14 @@
 import { NotFoundSection } from './styles'
 import notFound from '../../assets/img/not_found.gif'
+import { useNavigate } from 'react-router-dom'
 
 const NotFound = (): JSX.Element => {
+  const navigate = useNavigate()
+
+  const goBack = () => {
+    navigate(-1)
+  }
+
   return (
     <NotFoundSection>
       <div>
@@ -11,10 +18,7 @@ const NotFound = (): JSX.Element => {
         <h1>해당 페이지를 찾지 못했습니다.</h1>
         <p>페이지가 존재하지 않거나, 더 이상 사용할 수 없는 페이지입니다.</p>
         <div className="error-btns">
-          <a
-            className="previous-btn err-btn"
-            href="javascript:history.go(-1)"
-          ></a>
+          <a className="previous-btn err-btn" href="#" onClick={goBack}></a>
           <a className="main-btn err-btn" href="/"></a>
         </div>
       </div>

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,7 +1,13 @@
 interface User {
-  userEmail: string | null
-  userPwd: string | null
+  username: string
+  password: string
 }
+
+// interface loginUser extends Omit<User, 'username' | 'password'> {
+//   username: string | null
+//   password: string | null
+// }
+
 interface Register {
   username: string
   password: string


### PR DESCRIPTION
## 개요

a태그 href에 javascript:history.go(-1)를 써서 발생한 워닝 없앴습니다.  

Login 인풋 이메일과 비밀번호 타입 interface를 잘못 지정해줘서  
로그인 요청시 공백 처리되는 문제를 해결하였습니다.  

## 상세 설명

Not Found 페이지 워닝

react-dom.development.js:67 Warning: A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML try using dangerouslySetInnerHTML instead. React was passed "javascript:history.go(-1)".

