### PR TITLE
design: 비밀번호 찾기 input 아이콘 & 내정보 UI 변경

### DIFF
--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -20,16 +20,6 @@ const FooterContainer = styled.footer`
   }
 `
 
-// const Inner = styled.div`
-//   height: 100%;
-//   margin: 0 auto;
-//   max-width: ${theme.space.INNER_MAXWIDTH};
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   padding: 0 2rem;
-// `
-
 const Text = styled.p`
   font-size: 0.6rem;
   display: flex;

--- a/src/components/NavBar/MyMenu/index.tsx
+++ b/src/components/NavBar/MyMenu/index.tsx
@@ -1,11 +1,11 @@
-import { Menu, MenuButton, MenuItem, MenuList } from '@chakra-ui/react'
 import { setLogout } from '@redux/auth/authSlice'
 import { useAppSelect } from '@redux/store.hooks'
 import { postLogout } from '@api/userAPI'
-import { DesktopMenu, MobileMenu } from './styles'
+import { Container, MobileMenu, Before } from './styles'
 import { ItemName } from '../styles'
 import { useDispatch } from 'react-redux'
 import { Link } from 'react-router-dom'
+import { useState } from 'react'
 
 const MyMenu = (): JSX.Element => {
   const dispatch = useDispatch()
@@ -19,36 +19,25 @@ const MyMenu = (): JSX.Element => {
     }
   }
 
+  const [opened, setOpened] = useState<boolean>(false)
+
   return useAppSelect(select => select.auth.isAuthorized) ? (
-    <>
-      <DesktopMenu>
-        <Menu>
-          <MenuButton
-            as={ItemName}
-            px={4}
-            py={2}
-            transition="all 0.2s"
-            border="0"
-          >
-            내 정보
-          </MenuButton>
-          <MenuList
-            bg={'rgba(47, 54, 60, 0.9)'}
-            borderRadius={'none'}
-            color={'white'}
-          >
-            <MenuItem>
-              <Link to="/mypetitions">나의 청원</Link>
-            </MenuItem>
-            <MenuItem>
-              <Link to="#">회원 정보 관리</Link>
-            </MenuItem>
-            <MenuItem>
-              <a onClick={handleLogout}>로그아웃</a>
-            </MenuItem>
-          </MenuList>
-        </Menu>
-      </DesktopMenu>
+    <Container>
+      <details className="details_overlay">
+        <summary
+          onClick={() => {
+            setOpened(!opened)
+          }}
+        >
+          <Before open={opened}></Before>내 정보
+        </summary>
+        <div className="menu_list">
+          <Link to="/mypetitions">나의 청원</Link>
+          <div role="none" className="dropdown_divider"></div>
+          <Link to="#">회원 정보 관리</Link>
+          <a onClick={handleLogout}>로그아웃</a>
+        </div>
+      </details>
 
       <MobileMenu>
         <ItemName>
@@ -63,7 +52,7 @@ const MyMenu = (): JSX.Element => {
           </Link>
         </ItemName>
       </MobileMenu>
-    </>
+    </Container>
   ) : (
     <ItemName>
       <Link to="/login">로그인</Link>

--- a/src/components/NavBar/MyMenu/styles.ts
+++ b/src/components/NavBar/MyMenu/styles.ts
@@ -60,7 +60,7 @@ const Container = styled.div`
       display: flex;
       flex-direction: column;
       width: 8rem;
-      box-shadow: 0px 2px 5px 0.5px #22272e;
+      box-shadow: 0px 1px 4px 0.5px #22272e;
       padding: 8px 0;
       z-index: 1000;
       ::before {
@@ -83,6 +83,7 @@ const Container = styled.div`
         font-weight: 400;
 
         padding: 4px 8px 4px 16px;
+        margin: 2px 0;
         display: inline-block;
         width: 100%;
         text-align: left;

--- a/src/components/NavBar/MyMenu/styles.ts
+++ b/src/components/NavBar/MyMenu/styles.ts
@@ -1,29 +1,125 @@
 import styled from '@emotion/styled'
 import theme from '@style/theme'
 
-const DesktopMenu = styled.div`
-  display: none;
-  @media screen and (min-width: ${theme.breakpoints.md}) {
-    display: block;
-  }
-  .chakra-menu__menuitem {
-    &:hover {
-      cursor: pointer;
-      background-color: rgba(47, 54, 60, 0.94);
+const Container = styled.div`
+  .details_overlay {
+    margin: 1rem;
+    padding: 1rem;
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: white;
+    border: 2px solid transparent;
+    text-align: center;
+    cursor: pointer;
+    display: none;
+
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      display: block;
+      font-size: 1.125rem;
+      margin: 0px 0px 5px 40px;
+      padding: 5px 0px 3px 0px;
     }
-    &:focus {
-      outline: 'none';
-      background-color: rgba(47, 54, 60, 0.9);
+
+    summary {
+      list-style: none;
+      &::-webkit-details-marker {
+        display: none;
+      }
+
+      -ms-user-select: none;
+      -moz-user-select: -moz-none;
+      -khtml-user-select: none;
+      -webkit-user-select: none;
+      user-select: none;
+      &:hover {
+        text-decoration: underline #d52425;
+        text-underline-position: under;
+      }
+      .before_summary {
+        position: fixed;
+        top: 0;
+        right: 0;
+        bottom: 0;
+        left: 0;
+        z-index: 80;
+        height: 100vh;
+        display: none;
+        cursor: default;
+        content: ' ';
+        background: transparent;
+      }
+    }
+
+    .menu_list {
+      position: absolute;
+      right: 24px;
+      top: 90%;
+      background-color: rgb(47, 54, 60);
+      color: white;
+      border: 2px solid #22272e;
+      display: flex;
+      flex-direction: column;
+      width: 8rem;
+      box-shadow: 0px 2px 5px 0.5px #22272e;
+      padding: 8px 0;
+      z-index: 1000;
+      ::before {
+        top: -19px;
+        right: 16px;
+        border: 9px solid transparent;
+        border-bottom-color: #22272e;
+        position: absolute;
+        content: '';
+      }
+      ::after {
+        top: -15px;
+        right: 17px;
+        border: 8px solid transparent;
+        border-bottom-color: rgb(47, 54, 60);
+        position: absolute;
+        content: '';
+      }
+      a {
+        font-weight: 400;
+
+        padding: 4px 8px 4px 16px;
+        display: inline-block;
+        width: 100%;
+        text-align: left;
+        font-size: 1rem;
+        &:hover {
+          background-color: #316dca;
+        }
+      }
+      .dropdown_divider {
+        height: 0;
+        width: 100%;
+        margin: 8px 0;
+        border: 1px solid #22272e;
+        box-sizing: border-box;
+      }
     }
   }
 `
 
+const Before = styled.div<{ open: boolean }>`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 80;
+  height: 100vh;
+  display: ${props => (props.open ? 'block' : 'none')};
+  cursor: default;
+  content: ' ';
+  background: transparent;
+`
 const MobileMenu = styled.div`
   display: block;
   @media screen and (min-width: ${theme.breakpoints.md}) {
     display: none;
   }
-  /* height: 100vh; */
 `
 
-export { DesktopMenu, MobileMenu }
+export { Container, MobileMenu, Before }

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -47,11 +47,9 @@ const NavBar = (): JSX.Element => {
           </div>
         </TopMenu>
         <MobMenuButton
-          colorScheme={'black'}
           onClick={() => {
             setOpened(!opened)
           }}
-          display={{ base: 'block', md: 'none' }}
           open={opened}
         >
           <MobMenuIcon />

--- a/src/components/NavBar/styles.ts
+++ b/src/components/NavBar/styles.ts
@@ -3,6 +3,8 @@ import theme from '@style/theme'
 import { Button, List } from '@chakra-ui/react'
 
 const Header = styled.header`
+  backdrop-filter: blur(1.5px);
+
   height: 3.75rem;
   width: 100%;
   position: fixed;

--- a/src/components/NavBar/styles.ts
+++ b/src/components/NavBar/styles.ts
@@ -92,6 +92,18 @@ const MobMenuButton = styled(Button)`
   right: 0;
   height: 100%;
   transform: ${props => (props.open ? 'rotate(-90deg)' : 'none')};
+  display: block;
+  /* background: rgba(47, 54, 60, 0.9); */
+  background: transparent;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    display: none;
+  }
+  :focus {
+    box-shadow: none;
+  }
+  :hover {
+    background: transparent;
+  }
 `
 
 export { Header, Logo, TopMenu, ItemName, MobMenuButton }

--- a/src/components/PaginationButtons/index.tsx
+++ b/src/components/PaginationButtons/index.tsx
@@ -1,19 +1,16 @@
 import {
   PaginationPage,
-  PaginationContainer,
-  Pagination,
   usePagination,
   PaginationSeparator,
+  PaginationPrevious,
+  PaginationNext,
+  Pagination,
+  PaginationPageGroup,
 } from '@ajna/pagination'
-
 import qs from 'qs'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import {
-  PetitionsPaginationNext,
-  PetitionsPaginationPageGroup,
-  PetitionsPaginationPrevious,
-} from './styles'
+import { SPaginationContainer } from './styles'
 
 const PaginationButtons = ({
   getPetitions,
@@ -60,75 +57,15 @@ const PaginationButtons = ({
       currentPage={currentPage}
       onPageChange={handlePageChange}
     >
-      <PaginationContainer
-        mt="40px"
-        flexWrap={{ base: 'wrap', md: 'nowrap' }}
-        justifyContent={{ base: 'space-between', md: 'center' }}
-      >
-        <PetitionsPaginationPrevious
-          fontSize={{ base: '12px', md: 'sm' }}
-          _focus={{ outline: 'none' }}
-          h={{ base: '30px', md: '40px' }}
-          w={{ base: '4rem', md: '5.75rem' }}
-        >
-          이전
-        </PetitionsPaginationPrevious>
-        <PetitionsPaginationPageGroup
-          w={{ base: '', md: '100%' }}
-          separator={
-            <PaginationSeparator
-              bg="#fff"
-              border="1px solid #ccc"
-              borderRadius="0"
-              fontSize="sm"
-              w={{ base: '22.5px', md: '30px' }}
-              h={{ base: '30px', md: '40px' }}
-              m={{ base: '0 3px', md: '0 10px' }}
-              jumpSize={10}
-              _focus={{
-                outline: 'none',
-              }}
-            />
-          }
-        >
+      <SPaginationContainer>
+        <PaginationPrevious>이전</PaginationPrevious>
+        <PaginationPageGroup separator={<PaginationSeparator jumpSize={10} />}>
           {pages.map((page: number) => (
-            <PaginationPage
-              w={{ base: '30px', md: '40px' }}
-              h={{ base: '30px', md: '40px' }}
-              bg="#fff"
-              border="1px solid #ccc"
-              borderRadius="0"
-              fontSize={{ base: '12px', md: 'sm' }}
-              _hover={{
-                bg: '#2F363C',
-                color: '#fff',
-                border: 'none',
-              }}
-              key={`pagination_page_${page}`}
-              page={page}
-              _current={{
-                bg: '#2F363C',
-                color: '#fff',
-                border: 'none',
-              }}
-              _focus={{
-                outline: 'none',
-              }}
-              _active={{
-                bg: '#2F363C',
-              }}
-            />
+            <PaginationPage key={`pagination_page_${page}`} page={page} />
           ))}
-        </PetitionsPaginationPageGroup>
-        <PetitionsPaginationNext
-          fontSize={{ base: '12px', md: 'sm' }}
-          _focus={{ outline: 'none' }}
-          h={{ base: '30px', md: '40px' }}
-          w={{ base: '4rem', md: '5.75rem' }}
-        >
-          다음
-        </PetitionsPaginationNext>
-      </PaginationContainer>
+        </PaginationPageGroup>
+        <PaginationNext>다음</PaginationNext>
+      </SPaginationContainer>
     </Pagination>
   )
 }

--- a/src/components/PaginationButtons/styles.ts
+++ b/src/components/PaginationButtons/styles.ts
@@ -1,31 +1,84 @@
-import {
-  PaginationNext,
-  PaginationPageGroup,
-  PaginationPrevious,
-} from '@ajna/pagination'
-
+import { PaginationContainer } from '@ajna/pagination'
 import theme from '@style/theme'
 import styled from '@emotion/styled'
 
-const PetitionsPaginationPrevious = styled(PaginationPrevious)`
-  background-color: ${theme.color.WHITE};
-  border: 1px solid ${theme.color.LIGHT_GRAY};
-  border-radius: 0;
-  /* width: ${theme.size.PAGINATION_WIDTH}; ; */
-`
-const PetitionsPaginationPageGroup = styled(PaginationPageGroup)`
-  justify-content: center;
+const SPaginationContainer = styled(PaginationContainer)`
+  margin-top: 40px;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    flex-wrap: nowrap;
+    justify-content: center;
+  }
+
+  > button {
+    background-color: ${theme.color.WHITE};
+    border: 1px solid ${theme.color.LIGHT_GRAY};
+    border-radius: 0;
+    font-size: 12px;
+    height: 30px;
+    width: 4rem;
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      font-size: 1rem;
+      height: 40px;
+      width: 5.75rem;
+    }
+    :focus {
+      box-shadow: none;
+    }
+  }
+
+  ol {
+    justify-content: center;
+    /* w={{ base: '', md: '100%' }} */
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      width: 100%;
+    }
+    .pagination-page {
+      width: 30px;
+      height: 30px;
+      border: 1px solid #ccc;
+      border-radius: 0;
+      font-size: 12px;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        width: 40px;
+        height: 40px;
+        font-size: 1rem;
+      }
+      :hover {
+        background-color: #2f363c;
+        color: #fff;
+        border: none;
+      }
+      :focus {
+        box-shadow: none;
+      }
+    }
+    [aria-current='true'] {
+      background-color: #2f363c;
+      color: #fff;
+    }
+    [aria-current='false'] {
+      background-color: #fff;
+    }
+  }
+  .pagination-separator {
+    background-color: #fff;
+    border: 1px solid #ccc;
+    border-radius: 0;
+    font-size: 1rem;
+    width: 22.5px;
+    height: 30px;
+    margin: 0 3px;
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      width: 30px;
+      height: 40px;
+      margin: 0 10px;
+    }
+    :focust {
+      box-shadow: none;
+    }
+  }
 `
 
-const PetitionsPaginationNext = styled(PaginationNext)`
-  background-color: ${theme.color.WHITE};
-  border: 1px solid ${theme.color.LIGHT_GRAY};
-  border-radius: 0;
-  /* width: ${theme.size.PAGINATION_WIDTH}; */
-`
-
-export {
-  PetitionsPaginationPrevious,
-  PetitionsPaginationNext,
-  PetitionsPaginationPageGroup,
-}
+export { SPaginationContainer }

--- a/src/components/PetitionList/index.tsx
+++ b/src/components/PetitionList/index.tsx
@@ -1,22 +1,9 @@
-import { Text, UnorderedList } from '@chakra-ui/react'
 import qs from 'qs'
 import { useEffect, useState } from 'react'
-import { Link, Outlet, useNavigate } from 'react-router-dom'
+import { Link, Outlet } from 'react-router-dom'
 import { getDay } from '@utils/time'
 
-import {
-  PetitionAgreement,
-  PetitionCategory,
-  PetitionDate,
-  PetitionItem,
-  PetitionSubject,
-  PetitionsAgreement,
-  PetitionsCategory,
-  PetitionsDate,
-  PetitionsHead,
-  PetitionsHeadWrap,
-  PetitionsSubject,
-} from './styles'
+import { PetitionsHead, PetitionsUl } from './styles'
 
 const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
   const queryParams: any = qs.parse(location.search, {
@@ -36,65 +23,30 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
 
   return (
     <>
-      <PetitionsHead display={{ base: 'none', md: 'flex' }}>
-        <PetitionsHeadWrap>
-          <PetitionsCategory>분류</PetitionsCategory>
-          <PetitionsSubject>제목</PetitionsSubject>
-          <PetitionsDate>날짜</PetitionsDate>
-          <PetitionsAgreement>참여인원</PetitionsAgreement>
-        </PetitionsHeadWrap>
+      <PetitionsHead>
+        <div className="head_wrap">
+          <div className="head_category">분류</div>
+          <div className="head_subject">제목</div>
+          <div className="head_date">날짜</div>
+          <div className="head_agreements">참여인원</div>
+        </div>
       </PetitionsHead>
 
-      <UnorderedList ml={0}>
+      <PetitionsUl className="petition_list">
         {petitionList.map(petition => (
-          <PetitionItem key={petition.id}>
-            <PetitionCategory
-              position={{ md: 'absolute' }}
-              left={{ md: '10px' }}
-              bottom={{ md: '0' }}
-              top={{ md: '0' }}
-              h={{ md: '16px' }}
-              m={{ md: 'auto' }}
-              fontSize={{ base: '14px', md: '16px' }}
-            >
-              {petition.categoryName}
-            </PetitionCategory>
-            <PetitionSubject
-              pb={{ base: '10px', md: '0' }}
-              m={{ base: '25px 0 20px 0', md: '0 220px 0 200px' }}
-            >
-              <Link
-                to={`/petitions/${petition.id}`}
-                style={{ display: 'inline-block', width: '100%' }}
-              >
-                {petition.title}
-              </Link>
-            </PetitionSubject>
-            <PetitionDate
-              right={{ md: '90px' }}
-              w={{ md: '130px' }}
-              bottom={{ base: '20px', md: '0' }}
-              top={{ md: '0' }}
-              h={{ md: '16px' }}
-              m={{ md: 'auto' }}
-              textAlign={'center'}
-            >
-              {getDay(petition.createdAt)}
-            </PetitionDate>
-            <PetitionAgreement
-              w={{ md: '90px' }}
-              bottom={{ base: '20px', md: '0' }}
-              top={{ md: '0' }}
-              h={{ md: '16px' }}
-              m={{ md: 'auto' }}
-              textAlign={'center'}
-            >
+          <li key={petition.id}>
+            <div className="category">{petition.categoryName}</div>
+            <div className="subject">
+              <Link to={`/petitions/${petition.id}`}>{petition.title}</Link>
+            </div>
+            <div className="date">{getDay(petition.createdAt)}</div>
+            <div className="agreements">
               {petition.agreements}
-              <Text display={{ base: 'inline-block', md: 'none' }}>명</Text>
-            </PetitionAgreement>
-          </PetitionItem>
+              <span>명</span>
+            </div>
+          </li>
         ))}
-      </UnorderedList>
+      </PetitionsUl>
       <Outlet />
     </>
   )

--- a/src/components/PetitionList/styles.ts
+++ b/src/components/PetitionList/styles.ts
@@ -41,7 +41,7 @@ const PetitionsAgreement = styled.div`
 
 const PetitionCategory = styled(Box)`
   position: absolute;
-  color: #1197d4;
+  color: #8a8a8a;
 `
 const PetitionSubject = styled(Box)`
   text-align: left;

--- a/src/components/PetitionList/styles.ts
+++ b/src/components/PetitionList/styles.ts
@@ -1,88 +1,129 @@
-import { Box, ListItem } from '@chakra-ui/react'
 import styled from '@emotion/styled'
+import theme from '@style/theme'
 
-const PetitionsHead = styled(Box)`
+const PetitionsHead = styled.div`
   text-align: center;
   height: 50px;
   width: 100%;
   border-bottom: 1px solid #ddd;
   padding: 10px 0;
-  /* display: flex; */
   align-items: center;
-`
-const PetitionsHeadWrap = styled(Box)`
-  position: relative;
-  width: 100%;
-`
+  display: none;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    display: flex;
+  }
 
-const PetitionsCategory = styled.div`
-  position: absolute;
-  top: 0;
-  width: 150px;
-`
-const PetitionsSubject = styled.div`
-  margin-left: 200px;
-  margin-right: 220px;
-`
-const PetitionsDate = styled.div`
-  position: absolute;
-  top: 0;
-  right: 90px;
-  width: 130px;
-  text-align: center;
-`
-const PetitionsAgreement = styled.div`
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 90px;
-  text-align: center;
-`
-
-const PetitionCategory = styled(Box)`
-  position: absolute;
-  color: #8a8a8a;
-`
-const PetitionSubject = styled(Box)`
-  text-align: left;
-  display: block;
-  word-break: break-all;
-  :hover {
-    text-decoration: underline;
+  .head_wrap {
+    position: relative;
+    width: 100%;
+    .head_category {
+      position: absolute;
+      top: 0;
+      width: 150px;
+    }
+    .head_subject {
+      margin-left: 200px;
+      margin-right: 220px;
+    }
+    .head_date {
+      position: absolute;
+      top: 0;
+      right: 90px;
+      width: 130px;
+      text-align: center;
+    }
+    .head_agreements {
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: 90px;
+      text-align: center;
+    }
   }
 `
-const PetitionDate = styled(Box)`
-  position: absolute;
-  color: #8a8a8a;
-  font-weight: 300;
-`
 
-const PetitionAgreement = styled(Box)`
-  position: absolute;
-  right: 0;
-  color: #df3127;
-`
+const PetitionsUl = styled.ul`
+  margin-left: 0;
 
-const PetitionItem = styled(ListItem)`
-  position: relative;
-  padding: 20px 0;
-  border-bottom: 1px solid #ddd;
-  :hover {
-    background-color: #f8f8f8;
+  li {
+    position: relative;
+    padding: 20px 0;
+    border-bottom: 1px solid #ddd;
+    :hover {
+      background-color: #f8f8f8;
+    }
+    display: block;
+
+    .category {
+      font-size: 14px;
+      position: absolute;
+      color: #8a8a8a;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        position: absolute;
+        left: 10px;
+        bottom: 0;
+        top: 0;
+        height: 16px;
+        margin: auto;
+        font-size: 1rem;
+      }
+    }
+    .subject {
+      text-align: left;
+      display: block;
+      word-break: break-all;
+      padding-bottom: 10px;
+      margin: 25px 0 20px 0;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        padding-bottom: 0;
+        margin: 0 220px 0 200px;
+      }
+      :hover {
+        text-decoration: underline;
+      }
+      > a {
+        display: inline-block;
+        width: 100%;
+      }
+    }
+    .date {
+      bottom: 20px;
+      position: absolute;
+      color: #8a8a8a;
+      font-weight: 300;
+      text-align: center;
+
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        right: 90px;
+        width: 130px;
+        bottom: 0;
+        top: 0;
+        height: 16px;
+        margin: auto;
+      }
+    }
+    .agreements {
+      text-align: center;
+      bottom: 20px;
+      position: absolute;
+      right: 0;
+      color: #df3127;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        width: 90px;
+        bottom: 0;
+        top: 0;
+        height: 1rem;
+        margin: auto;
+      }
+
+      > span {
+        display: inline-block;
+        @media screen and (min-width: ${theme.breakpoints.md}) {
+          display: none;
+        }
+      }
+    }
   }
-  display: block;
 `
 
-export {
-  PetitionsHead,
-  PetitionsHeadWrap,
-  PetitionsCategory,
-  PetitionsSubject,
-  PetitionsDate,
-  PetitionsAgreement,
-  PetitionItem,
-  PetitionCategory,
-  PetitionSubject,
-  PetitionDate,
-  PetitionAgreement,
-}
+export { PetitionsHead, PetitionsUl }

--- a/src/pages/AnsweredPetitions/index.tsx
+++ b/src/pages/AnsweredPetitions/index.tsx
@@ -1,5 +1,4 @@
 import { PetitionBoard } from './styles'
-import { Stack } from '@chakra-ui/react'
 import { PetitionsText, PetitionsTitle } from './styles'
 import PaginationButtons from '@components/PaginationButtons'
 import PetitionList from '@components/PetitionList'
@@ -18,12 +17,12 @@ const AnsweredPetitions = (): JSX.Element => {
             <PetitionsText>답변된 청원</PetitionsText>
           </PetitionsTitle>
           <PetitionList getPetitions={getAnsweredByQuery} />
-          <Stack>
+          <div className="pagination">
             <PaginationButtons
               getPetitions={getAnsweredByQuery}
               pathname={'/answer'}
             />
-          </Stack>
+          </div>
         </PetitionBoard>
       </Inner>
     </>

--- a/src/pages/AnsweredPetitions/index.tsx
+++ b/src/pages/AnsweredPetitions/index.tsx
@@ -1,5 +1,5 @@
-import { PetitionBoard } from './styles'
-import { PetitionsText, PetitionsTitle } from './styles'
+import { Container, PetitionBoard } from './styles'
+import { Stack } from '@chakra-ui/react'
 import PaginationButtons from '@components/PaginationButtons'
 import PetitionList from '@components/PetitionList'
 import { getAnsweredByQuery } from '@api/petitionAPI'
@@ -10,14 +10,14 @@ const AnsweredPetitions = (): JSX.Element => {
   const navigate = useNavigate()
 
   return (
-    <>
+    <Container>
       <Inner>
         <PetitionBoard>
-          <PetitionsTitle>
-            <PetitionsText>답변된 청원</PetitionsText>
-          </PetitionsTitle>
+          <div className="petition_type">
+            <span>답변된 청원</span>
+          </div>
           <PetitionList getPetitions={getAnsweredByQuery} />
-          <div className="pagination">
+          <div>
             <PaginationButtons
               getPetitions={getAnsweredByQuery}
               pathname={'/answer'}
@@ -25,7 +25,7 @@ const AnsweredPetitions = (): JSX.Element => {
           </div>
         </PetitionBoard>
       </Inner>
-    </>
+    </Container>
   )
 }
 

--- a/src/pages/AnsweredPetitions/styles.ts
+++ b/src/pages/AnsweredPetitions/styles.ts
@@ -1,30 +1,23 @@
 import styled from '@emotion/styled'
-import { Box, Select, Text } from '@chakra-ui/react'
+
+const Container = styled.div``
 
 const PetitionBoard = styled.div`
   position: relative;
   margin-top: 9.375rem;
-  text-align: center;
-`
-const PetitionsTitle = styled(Box)`
-  display: flex;
-  justify-content: space-between;
-  padding-bottom: 5px;
-  border-bottom: 2px solid #333;
+
+  .petition_type {
+    display: flex;
+    border-bottom: 2px solid #333;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 1rem;
+
+    span {
+      font-size: 20px;
+      font-weight: bold;
+    }
+  }
 `
 
-const PetitionsSelect = styled(Select)`
-  width: 128px;
-  height: 40px;
-  border-radius: 0;
-  border-color: #ccc;
-`
-
-const PetitionsText = styled(Text)`
-  font-size: 20px;
-  font-weight: bold;
-  height: 40px;
-  margin-bottom: 1px;
-`
-
-export { PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }
+export { Container, PetitionBoard }

--- a/src/pages/FindingPassword/index.tsx
+++ b/src/pages/FindingPassword/index.tsx
@@ -10,10 +10,13 @@ import {
   Spinner,
   Flex,
   useToast,
+  InputRightElement,
+  IconButton,
 } from '@chakra-ui/react'
 import theme from '@style/theme'
-import { FaUserAlt, FaLock } from 'react-icons/fa'
-import { RegisterButton, stackStyle, ErrorText } from './styles'
+import { FaUserAlt, FaLock, FaCheck } from 'react-icons/fa'
+import { MdPassword } from 'react-icons/md'
+import { RegisterButton, Container } from './styles'
 import { useNavigate } from 'react-router-dom'
 import { RootState } from '@redux/store'
 import {
@@ -23,10 +26,14 @@ import {
 } from '@api/verificationAPI'
 import { setFindPasswordWhichInfo } from '@redux/findPassword/findPasswordSlice'
 import { useAppDispatch, useAppSelect } from '@redux/store.hooks'
+import { ViewIcon, ViewOffIcon } from '@chakra-ui/icons'
 
 const FindingPassword = (): JSX.Element => {
   const CFaUserAlt = chakra(FaUserAlt)
+  const CMdPassword = chakra(MdPassword)
   const CFaLock = chakra(FaLock)
+  const CFaCheck = chakra(FaCheck)
+
   const navigate = useNavigate()
   const emailRef = useRef<HTMLInputElement>(null)
   const verificationRef = useRef<HTMLInputElement>(null)
@@ -37,6 +44,9 @@ const FindingPassword = (): JSX.Element => {
     verificationCode: '',
     passwordConfirm: '',
   })
+  const [viewPassword, setViewPassword] = useState<boolean>(false)
+  const handleShowClick = () => setViewPassword(!viewPassword)
+
   const whichUI = useAppSelect((state: RootState) => state.findPassword)
   const dispatch = useAppDispatch()
   const toast = useToast({
@@ -176,15 +186,13 @@ const FindingPassword = (): JSX.Element => {
   }
 
   return (
-    <section className="register">
-      <form onSubmit={handleSubmit} className="register__form">
-        <Stack spacing={4} style={stackStyle}>
-          <Text fontSize="4xl" fontWeight="bold">
-            비밀번호 찾기
-          </Text>
+    <Container className="register">
+      <form onSubmit={handleSubmit} className="register_form">
+        <Stack spacing={4}>
+          <span>비밀번호 찾기</span>
           <FormControl isRequired>
-            <Text mb="8px">이메일</Text>
-            <InputGroup borderColor={`${theme.color.ligthGray}`}>
+            <span>이메일</span>
+            <InputGroup>
               <InputLeftElement>
                 {<CFaUserAlt color="gray.300" />}
               </InputLeftElement>
@@ -206,7 +214,7 @@ const FindingPassword = (): JSX.Element => {
               <Text mb="8px">인증 코드</Text>
               <InputGroup borderColor={`${theme.color.ligthGray}`}>
                 <InputLeftElement>
-                  {<CFaLock color="gray.300" />}
+                  {<CMdPassword color="gray.300" />}
                 </InputLeftElement>
                 <Input
                   ref={verificationRef}
@@ -231,13 +239,22 @@ const FindingPassword = (): JSX.Element => {
                 </InputLeftElement>
                 <Input
                   ref={passwordRef}
-                  type="password"
+                  type={viewPassword ? 'text' : 'password'}
                   name="password"
                   placeholder="영문과 숫자를 포함한 8자리 이상의 비밀번호를 입력하세요"
                   value={input.password}
                   onChange={handleChange}
                   borderRadius="0"
                 ></Input>
+                <InputRightElement>
+                  <IconButton
+                    color="gray.300"
+                    aria-label="view password"
+                    variant="password"
+                    icon={viewPassword ? <ViewOffIcon /> : <ViewIcon />}
+                    onClick={handleShowClick}
+                  ></IconButton>
+                </InputRightElement>
               </InputGroup>
             </FormControl>
           )}
@@ -246,16 +263,25 @@ const FindingPassword = (): JSX.Element => {
               <Text mb="8px">비밀번호 확인</Text>
               <InputGroup borderColor={`${theme.color.ligthGray}`}>
                 <InputLeftElement>
-                  {<CFaLock color="gray.300" />}
+                  {<CFaCheck color="gray.300" />}
                 </InputLeftElement>
                 <Input
-                  type="password"
+                  type={viewPassword ? 'text' : 'password'}
                   name="passwordConfirm"
                   placeholder="비밀번호를 재입력하세요"
                   value={input.passwordConfirm}
                   onChange={handleChange}
                   borderRadius="0"
                 ></Input>
+                <InputRightElement>
+                  <IconButton
+                    color="gray.300"
+                    aria-label="view password"
+                    variant="password"
+                    icon={viewPassword ? <ViewOffIcon /> : <ViewIcon />}
+                    onClick={handleShowClick}
+                  ></IconButton>
+                </InputRightElement>
               </InputGroup>
             </FormControl>
           )}
@@ -302,10 +328,10 @@ const FindingPassword = (): JSX.Element => {
               비밀번호 재설정
             </RegisterButton>
           )}
-          <ErrorText>{errorText}</ErrorText>
+          <span className="err_msg">{errorText}</span>
         </Stack>
       </form>
-    </section>
+    </Container>
   )
 }
 

--- a/src/pages/FindingPassword/styles.ts
+++ b/src/pages/FindingPassword/styles.ts
@@ -1,16 +1,36 @@
 import styled from '@emotion/styled'
 import theme from '@style/theme'
 
-const stackStyle: React.CSSProperties = {
-  position: 'absolute',
-  top: '10rem',
-  left: '0',
-  right: '0',
-  height: '31.25rem',
-  width: '25rem',
-  margin: 'auto',
-}
+const Container = styled.section`
+  .register_form > .chakra-stack {
+    height: 100vh;
+    max-width: 28rem;
+    margin: auto;
+    justify-content: center;
+    padding: 0 2rem;
 
+    > span:nth-of-type(1) {
+      font-size: 2rem;
+      font-weight: bold;
+    }
+    .chakra-form-control {
+      > span {
+        display: inline-block;
+        margin-bottom: 0.5rem;
+      }
+      .chakra-input__group {
+        border-color: #ccc;
+        .chakra-input {
+          border-radius: 0;
+        }
+      }
+    }
+    .err_msg {
+      text-align: center;
+      color: ${theme.color.PRIMARY_RED};
+    }
+  }
+`
 const RegisterButton = styled.button`
   color: ${theme.color.WHITE};
   background-color: ${theme.color.TERTIARY_GRAY};
@@ -19,10 +39,6 @@ const RegisterButton = styled.button`
   font-weight: bold;
 `
 
-const ErrorText = styled.p`
-  text-align: center;
-  color: ${theme.color.PRIMARY_RED};
-`
 const DeleteBtn = styled.button`
   position: absolute;
   top: 1em;
@@ -35,4 +51,4 @@ const DeleteBtn = styled.button`
   font-weight: bold;
 `
 
-export { stackStyle, RegisterButton, ErrorText, DeleteBtn }
+export { Container, RegisterButton, DeleteBtn }

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, useEffect, useRef, useState } from 'react'
-import { Link, useNavigate } from 'react-router-dom'
+import { Link } from 'react-router-dom'
 import { setLogin } from '@redux/auth/authSlice'
 import {
   Button,
@@ -15,7 +15,7 @@ import {
 import { Container } from './styles'
 import { FaUserAlt, FaLock } from 'react-icons/fa'
 import { postLogin } from '@api/userAPI'
-import { useAppDispatch, useAppSelect } from '../../redux/store.hooks'
+import { useAppDispatch, useAppSelect } from '@redux/store.hooks'
 import { ViewOffIcon, ViewIcon } from '@chakra-ui/icons'
 
 const Login = (): JSX.Element => {
@@ -37,7 +37,6 @@ const Login = (): JSX.Element => {
   const email = useRef<HTMLInputElement>(null)
   const pwd = useRef<HTMLInputElement>(null)
 
-  const navigate = useNavigate()
   const dispatch = useAppDispatch()
 
   const checkUpperCase = (e: any) => {
@@ -126,7 +125,7 @@ const Login = (): JSX.Element => {
           </FormControl>
           <span className="err_msg">{checkLoginError(responseState)}</span>
           <span className="forgot_pwd account_link">
-            <Link to="#">비밀번호를 잊으셨나요?</Link>
+            <a href="/findpassword">비밀번호를 잊으셨나요?</a>
           </span>
 
           <Button

--- a/src/pages/Login/styles.ts
+++ b/src/pages/Login/styles.ts
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import theme from '@style/theme'
 
-const Container = styled.div`
+const Container = styled.section`
   .login_form > .chakra-stack {
     height: 100vh;
     max-width: 28rem;
@@ -17,7 +17,7 @@ const Container = styled.div`
     .chakra-form-control {
       > span {
         display: inline-block;
-        margin-bottom: 8px;
+        margin-bottom: 0.5rem;
       }
       .chakra-input__group {
         border-color: #ccc;

--- a/src/pages/MyPetitions/MyPetitionList/index.tsx
+++ b/src/pages/MyPetitions/MyPetitionList/index.tsx
@@ -5,18 +5,9 @@ import { Link, Outlet } from 'react-router-dom'
 import { getDay } from '@utils/time'
 
 import {
-  PetitionAgreement,
+  PetitionsUl,
   PetitionCategory,
-  PetitionDate,
-  PetitionItem,
-  PetitionSubject,
-  PetitionsAgreement,
-  PetitionsCategory,
-  PetitionsDate,
   PetitionsHead,
-  PetitionsHeadWrap,
-  PetitionsSubject,
-  PetitionsStatus,
   PetitionStatus,
   PetitionStatusTag,
   PetitionTagWrapper,
@@ -40,76 +31,42 @@ const MyPetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
 
   return (
     <>
-      <PetitionsHead display={{ base: 'none', md: 'flex' }}>
-        <PetitionsHeadWrap>
-          <PetitionsStatus>진행 상황</PetitionsStatus>
-          <PetitionsCategory>분류</PetitionsCategory>
-          <PetitionsSubject>제목</PetitionsSubject>
-          <PetitionsDate>날짜</PetitionsDate>
-          <PetitionsAgreement>참여인원</PetitionsAgreement>
-        </PetitionsHeadWrap>
+      <PetitionsHead>
+        <div className="head_wrap">
+          <div className="head_status">진행 상황</div>
+          <div className="head_category">분류</div>
+          <div className="head_subject">제목</div>
+          <div className="head_date">날짜</div>
+          <div className="head_agreements">참여인원</div>
+        </div>
       </PetitionsHead>
 
-      <UnorderedList ml={0}>
+      <PetitionsUl className="petition_list">
         {petitionList.map(petition => (
-          <PetitionItem key={petition.id}>
+          <li key={petition.id}>
             <PetitionTagWrapper>
-              <PetitionStatus position={{ md: 'absolute' }}>
-                <PetitionStatusTag borderRadius={'none'}>
+              <PetitionStatus>
+                <PetitionStatusTag>
                   {!petition.answered ? '청원진행중' : '답변완료'}{' '}
-                  {/*petition.answered의 값이 적용이 잘 안 됨*/}
                 </PetitionStatusTag>
               </PetitionStatus>
-              <PetitionCategory
-                position={{ md: 'absolute' }}
-                left={{ md: '100px' }}
-                bottom={{ md: '0' }}
-                top={{ md: '0' }}
-                h={{ md: '16px' }}
-                m={{ base: '0', md: 'auto' }}
-                fontSize={{ base: '13px', md: '15px' }}
-                pl={{ base: '5px', md: '0' }} /* 모바일에서 pl값 추가함 */
-              >
+              <PetitionCategory className="category">
                 {petition.categoryName}
               </PetitionCategory>
             </PetitionTagWrapper>
-            <PetitionSubject
-              pb={{ base: '10px', md: '0' }}
-              pl={{ base: '5px', md: '0' }}
-              m={{ base: '5px 0 20px 0', md: '0 220px 0 250px' }}
-            >
-              <Link
-                to={`/petitions/temp/${petition.tempUrl}`}
-                style={{ display: 'inline-block', width: '100%' }}
-              >
+            <div className="subject">
+              <Link to={`/petitions/temp/${petition.tempUrl}`}>
                 {petition.title}
               </Link>
-            </PetitionSubject>
-            <PetitionDate
-              right={{ md: '90px' }}
-              w={{ md: '130px' }}
-              bottom={{ base: '20px', md: '0' }}
-              top={{ md: '0' }}
-              h={{ md: '16px' }}
-              m={{ md: 'auto' }}
-              pl={{ base: '5px', md: '0' }}
-            >
-              {getDay(petition.createdAt)}
-            </PetitionDate>
-            <PetitionAgreement
-              w={{ md: '90px' }}
-              bottom={{ base: '20px', md: '0' }}
-              top={{ md: '0' }}
-              h={{ md: '16px' }}
-              m={{ md: 'auto' }}
-              pr={{ base: '5px', md: '0' }}
-            >
+            </div>
+            <div className="date">{getDay(petition.createdAt)}</div>
+            <div className="agreements">
               {petition.agreements}
-              <Text display={{ base: 'inline-block', md: 'none' }}>명</Text>
-            </PetitionAgreement>
-          </PetitionItem>
+              <span>명</span>
+            </div>
+          </li>
         ))}
-      </UnorderedList>
+      </PetitionsUl>
       <Outlet />
     </>
   )

--- a/src/pages/MyPetitions/MyPetitionList/styles.ts
+++ b/src/pages/MyPetitions/MyPetitionList/styles.ts
@@ -1,54 +1,129 @@
-import { Box, ListItem, Tag } from '@chakra-ui/react'
+import { Tag } from '@chakra-ui/react'
 import theme from '@style/theme'
 import styled from '@emotion/styled'
 
-const PetitionsHead = styled(Box)`
+const PetitionsHead = styled.div`
   height: 50px;
   width: 100%;
   border-bottom: 1px solid #ddd;
   padding: 10px 0;
   align-items: center;
-`
-const PetitionsHeadWrap = styled(Box)`
-  position: relative;
-  width: 100%;
-  display: flex;
-`
-const PetitionsStatus = styled.div`
-  /* position: absolute; */
-  display: flex;
-  /* top: 0; */
-  width: 100px;
-  padding-left: 10px;
+  display: none;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    display: flex;
+  }
+
+  .head_wrap {
+    position: relative;
+    width: 100%;
+    display: flex;
+
+    .head_status {
+      display: flex;
+      width: 100px;
+      padding-left: 10px;
+    }
+    .head_category {
+      display: flex;
+      width: 100px;
+    }
+    .head_subject {
+      margin-left: 220px;
+      margin-right: 220px; // 제목 중앙에 배치 위한 코드
+      display: flex;
+    }
+    .head_date {
+      position: absolute;
+      display: flex;
+      top: 0;
+      right: 90px;
+      width: 80px;
+      text-align: center;
+    }
+    .head_agreements {
+      position: absolute;
+      right: 0;
+      top: 0;
+      width: 90px;
+      text-align: center;
+    }
+  }
 `
 
-const PetitionsCategory = styled.div`
-  /* position: absolute; */
-  display: flex;
-  /* top: 0; */
-  width: 100px;
+const PetitionsUl = styled.ul`
+  margin-left: 0;
+  li {
+    position: relative;
+    padding: 15px 0;
+    border-bottom: 1px solid #ddd;
+    :hover {
+      background-color: #f8f8f8;
+    }
+    display: block;
+
+    .subject {
+      text-align: left;
+      display: block;
+      word-break: break-all;
+      padding-bottom: 10px;
+      padding-left: 5px;
+      margin: 5px 0 20px 0;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        padding-left: 0;
+        padding-bottom: 0;
+        margin: 0 220px 0 200px;
+      }
+      :hover {
+        text-decoration: underline;
+      }
+      > a {
+        display: inline-block;
+        width: 100%;
+      }
+    }
+    .date {
+      bottom: 20px;
+      position: absolute;
+      color: #8a8a8a;
+      font-weight: 300;
+      text-align: center;
+      padding-left: 5px;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        right: 90px;
+        width: 130px;
+        bottom: 0;
+        top: 0;
+        height: 16px;
+        margin: auto;
+        padding-left: 0;
+      }
+    }
+    .agreements {
+      text-align: center;
+      bottom: 20px;
+      position: absolute;
+      right: 0;
+      color: #df3127;
+      padding-right: 5px;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        width: 90px;
+        bottom: 0;
+        top: 0;
+        height: 1rem;
+        margin: auto;
+        padding-right: 0;
+      }
+
+      > span {
+        display: inline-block;
+        @media screen and (min-width: ${theme.breakpoints.md}) {
+          display: none;
+        }
+      }
+    }
+  }
 `
-const PetitionsSubject = styled.div`
-  margin-left: 220px;
-  margin-right: 220px; // 제목 중앙에 배치 위한 코드
-  display: flex;
-`
-const PetitionsDate = styled.div`
-  position: absolute;
-  display: flex;
-  top: 0;
-  right: 90px;
-  width: 80px;
-  text-align: center;
-`
-const PetitionsAgreement = styled.div`
-  position: absolute;
-  right: 0;
-  top: 0;
-  width: 90px;
-  text-align: center;
-`
-const PetitionStatus = styled(Box)`
+const PetitionStatus = styled.div`
   height: 100%;
   display: flex;
   align-items: center;
@@ -56,53 +131,40 @@ const PetitionStatus = styled(Box)`
   padding-bottom: 15px; //모바일에서 category 사이 space 적용
   padding-left: 3px; // 모바일에서 category와의 배치가 어색해서 2px빼놓음
   @media screen and (min-width: ${theme.breakpoints.md}) {
+    position: absolute;
     font-size: 12px;
     padding-bottom: 0;
     padding-left: 5px;
   }
 `
-const PetitionCategory = styled(Box)`
-  color: #1197d4;
+const PetitionCategory = styled.div`
+  color: #8a8a8a;
   width: 130px;
   display: flex;
   align-items: center;
   bottom: 0%;
+  margin: 0;
+  font-size: 12px;
+  padding-left: 5px;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    position: absolute;
+    left: 100px;
+    bottom: 0;
+    top: 0;
+    height: 1rem;
+    margin: auto;
+    font-size: 1rem;
+    padding-left: 0;
+  }
 `
-const PetitionTagWrapper = styled(Box)`
+const PetitionTagWrapper = styled.div`
   // 모바일에서 PetitionCategory와 PetitionStatus 배치 조정 위한 Tag
   display: flex;
   flex-direction: column;
 `
-const PetitionSubject = styled(Box)`
-  text-align: left;
-  display: block;
-  word-break: break-all;
-  :hover {
-    text-decoration: underline;
-  }
-`
-const PetitionDate = styled(Box)`
-  position: absolute;
-  color: #8a8a8a;
-  font-weight: 300;
-`
 
-const PetitionAgreement = styled(Box)`
-  position: absolute;
-  right: 0;
-  color: #df3127;
-`
-
-const PetitionItem = styled(ListItem)`
-  position: relative;
-  padding: 15px 0;
-  border-bottom: 1px solid #ddd;
-  :hover {
-    background-color: #f8f8f8;
-  }
-  display: block;
-`
 const PetitionStatusTag = styled(Tag)`
+  border-radius: 0;
   font-size: 10px;
   background-color: ${theme.color.SECONDARY_RED}; //나머지 색은 QUATERNARY_GRAY
   color: white;
@@ -112,19 +174,10 @@ const PetitionStatusTag = styled(Tag)`
 `
 
 export {
+  PetitionsUl,
   PetitionsHead,
-  PetitionsHeadWrap,
-  PetitionsStatus,
-  PetitionsCategory,
-  PetitionsSubject,
-  PetitionsDate,
-  PetitionsAgreement,
-  PetitionItem,
   PetitionStatus,
   PetitionCategory,
-  PetitionSubject,
-  PetitionDate,
-  PetitionAgreement,
   PetitionStatusTag,
   PetitionTagWrapper,
 }

--- a/src/pages/MyPetitions/index.tsx
+++ b/src/pages/MyPetitions/index.tsx
@@ -1,4 +1,4 @@
-import { PetitionBoard, PetitionsText, PetitionsTitle } from './styles'
+import { Container, PetitionBoard } from './styles'
 import PaginationButtons from '@components/PaginationButtons'
 import { getMineByQuery } from '@api/petitionAPI'
 import MyPetitionList from './MyPetitionList'
@@ -9,20 +9,22 @@ const MyPetitions = (): JSX.Element => {
   const navigate = useNavigate()
 
   return (
-    <Inner>
-      <PetitionBoard>
-        <PetitionsTitle>
-          <PetitionsText>나의 청원</PetitionsText>
-        </PetitionsTitle>
-        <MyPetitionList getPetitions={getMineByQuery} />
-        <div className="pagination">
-          <PaginationButtons
-            getPetitions={getMineByQuery}
-            pathname={'/mypetitions'}
-          />
-        </div>
-      </PetitionBoard>
-    </Inner>
+    <Container>
+      <Inner>
+        <PetitionBoard>
+          <div className="petition_type">
+            <span>나의 청원</span>
+          </div>
+          <MyPetitionList getPetitions={getMineByQuery} />
+          <div className="pagination">
+            <PaginationButtons
+              getPetitions={getMineByQuery}
+              pathname={'/mypetitions'}
+            />
+          </div>
+        </PetitionBoard>
+      </Inner>
+    </Container>
   )
 }
 

--- a/src/pages/MyPetitions/index.tsx
+++ b/src/pages/MyPetitions/index.tsx
@@ -1,5 +1,4 @@
 import { PetitionBoard, PetitionsText, PetitionsTitle } from './styles'
-import { Stack } from '@chakra-ui/react'
 import PaginationButtons from '@components/PaginationButtons'
 import { getMineByQuery } from '@api/petitionAPI'
 import MyPetitionList from './MyPetitionList'
@@ -16,12 +15,12 @@ const MyPetitions = (): JSX.Element => {
           <PetitionsText>나의 청원</PetitionsText>
         </PetitionsTitle>
         <MyPetitionList getPetitions={getMineByQuery} />
-        <Stack>
+        <div className="pagination">
           <PaginationButtons
             getPetitions={getMineByQuery}
             pathname={'/mypetitions'}
           />
-        </Stack>
+        </div>
       </PetitionBoard>
     </Inner>
   )

--- a/src/pages/MyPetitions/styles.ts
+++ b/src/pages/MyPetitions/styles.ts
@@ -1,30 +1,22 @@
 import styled from '@emotion/styled'
-import { Box, Select, Text } from '@chakra-ui/react'
 
+const Container = styled.div``
 const PetitionBoard = styled.div`
   position: relative;
-  top: 9.375rem;
-  text-align: center;
-`
-const PetitionsTitle = styled(Box)`
-  display: flex;
-  justify-content: space-between;
-  padding-bottom: 5px;
-  border-bottom: 2px solid #333;
+  margin-top: 9.375rem;
+
+  .petition_type {
+    display: flex;
+    border-bottom: 2px solid #333;
+    justify-content: space-between;
+    align-items: center;
+    padding-bottom: 1rem;
+
+    span {
+      font-size: 20px;
+      font-weight: bold;
+    }
+  }
 `
 
-const PetitionsSelect = styled(Select)`
-  width: 128px;
-  height: 40px;
-  border-radius: 0;
-  border-color: #ccc;
-`
-
-const PetitionsText = styled(Text)`
-  font-size: 20px;
-  font-weight: bold;
-  height: 40px;
-  margin-bottom: 1px;
-`
-
-export { PetitionBoard, PetitionsTitle, PetitionsSelect, PetitionsText }
+export { Container, PetitionBoard }

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent, useState } from 'react'
 import {
   Select,
-  Stack,
   Tabs,
   TabList,
   TabPanels,
@@ -30,9 +29,11 @@ const Petitions = (): JSX.Element => {
     .fill(0)
     .map((_x, i) => i)
 
-  const [sortSelected, setSortSelected] = useState(queryParams?.sort)
+  const [sortSelected, setSortSelected] = useState<string>(
+    queryParams?.sort || '',
+  )
 
-  const [categorySelected, setCategorySelected] = useState(
+  const [categorySelected, setCategorySelected] = useState<number>(
     queryParams?.category || 0,
   )
   const navigate = useNavigate()
@@ -51,7 +52,6 @@ const Petitions = (): JSX.Element => {
 
   const handleCategorySelect = (e: ChangeEvent<HTMLSelectElement>) => {
     setCategorySelected(Number(e.target.value))
-    console.log(queryParams)
     const newSearchParams = {
       ...queryParams,
       page: 1,
@@ -84,7 +84,7 @@ const Petitions = (): JSX.Element => {
             </div>
           </div>
 
-          <Tabs isFitted colorScheme={'red'}>
+          <Tabs isFitted colorScheme="red">
             <TabList>
               <Tab>진행중인 청원</Tab>
               <Tab>만료된 청원</Tab>
@@ -93,22 +93,22 @@ const Petitions = (): JSX.Element => {
             <TabPanels>
               <TabPanel>
                 <PetitionList getPetitions={getPetitionsByQuery}></PetitionList>
-                <Stack>
+                <div className="pagination">
                   <PaginationButtons
                     getPetitions={getPetitionsByQuery}
                     pathname={'/petitions'}
                   />
-                </Stack>
+                </div>
               </TabPanel>
 
               <TabPanel>
                 <PetitionList getPetitions={getExpiredByQuery}></PetitionList>
-                <Stack>
+                <div className="pagination">
                   <PaginationButtons
                     getPetitions={getExpiredByQuery}
                     pathname={'/petitions'}
                   />
-                </Stack>
+                </div>
               </TabPanel>
             </TabPanels>
           </Tabs>

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useState } from 'react'
+import { ChangeEvent, useState } from 'react'
 import {
   Select,
   Stack,

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -71,7 +71,7 @@ const Petitions = (): JSX.Element => {
             <span>모든 청원</span>
             <div className="selects">
               <Select onChange={handleSortSelect} value={sortSelected}>
-                <option value={''}>최신순</option>
+                <option value={'createdAt,desc'}>최신순</option>
                 <option value={'agreeCount,desc'}>추천순</option>
               </Select>
               <Select onChange={handleCategorySelect} value={categorySelected}>

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -34,7 +34,7 @@ const breakpoints = createBreakpoints({
   md: '768px',
   lg: '960px',
   xl: '1200px',
-  '2xl': '1536px',
+  xxl: '1536px',
 })
 
 const theme = extendTheme({


### PR DESCRIPTION
## 개요

비밀번호 변경 페이지 input마다 아이콘 다르게 적용
NavBar 뒤쪽 블러처리
menu UI 디자인 변경 (chakra -> details 태그)

작성예정

## 미리보기

![스크린샷 2022-02-25 오후 12 32 31](https://user-images.githubusercontent.com/65757344/155648629-40bf511c-2208-4323-bfad-7a607b1958fd.png)

![스크린샷 2022-02-25 오후 12 31 21](https://user-images.githubusercontent.com/65757344/155648507-839d52bf-4173-43e6-8501-5dc3a81997be.png)


Emtion 태그 최소화 & 스타일 관련 코드 제외 결과
<img width="751" alt="스크린샷 2022-02-25 오후 2 08 17" src="https://user-images.githubusercontent.com/65757344/155657445-2bd2f182-5e6b-41b9-a61d-bb8250347dd0.png">

## 상세 설명

Chakra UI의 도입 이유는 어려운 기능적 UI를 쉽게 구현하거나  
새로운 UI를 빠르게 찍어내기 위함이었습니다.  
그러나, 이를 도입하면서 원하는대로 커스터마이징하기 어려워졌습니다. (ex) 메뉴 open, close 애니메이션)

따라서 Menu UI정도는 순수 html css로 구현하였고  

아울러 index.tsx 파일에서 최대한 styles.ts에 들어가야할 코드를 빼놓았습니다.  
이제 웬만한 경우 아니면 Chakra UI는 쓰지 않겠습니다.

## 기타

Close #225 Close #224 