### PR TITLE
refactor: petition/index.tsx 에서 모든 API 요청 상태 관리

### DIFF
--- a/src/pages/Petition/PetitionContents/AgreementForm/index.tsx
+++ b/src/pages/Petition/PetitionContents/AgreementForm/index.tsx
@@ -1,15 +1,20 @@
-import { FormControl, useDisclosure } from '@chakra-ui/react'
+import { FormControl } from '@chakra-ui/react'
 import { ChangeEvent, FormEvent, useState, useEffect } from 'react'
 import { getStateOfAgreement, postAgreePetition } from '@api/petitionAPI'
 import { SAgreementForm } from './styles'
 import { useNavigate } from 'react-router-dom'
-import NeedLoginModal from '@components/NeedLoginModal'
+import { useAppSelect } from '@redux/store.hooks'
 
-const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
+interface Props {
+  id: string
+  isConsented: boolean
+}
+
+const AgreementForm = ({ id, isConsented }: Props): JSX.Element => {
+  const isAuthorized = useAppSelect(select => select.auth.isAuthorized)
   const [input, setInput] = useState<AgreePetition>({
-    description: '동의합니다.',
+    description: '동의합니다',
   })
-  const [isConsented, setIsConsented] = useState<boolean>(true)
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setInput({ description: e.target.value.replace(/ +/g, ' ') })
@@ -19,61 +24,42 @@ const AgreementForm = ({ petitionId }: PetitionId): JSX.Element => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     try {
-      const response = await postAgreePetition(petitionId, input)
-      if (response?.status === 401) {
-        onOpen()
-      } else if (response.status < 400) {
-        navigate(0)
-        setIsConsented(true)
-      }
+      await postAgreePetition(id, input)
     } catch (error) {
       console.log(error)
     }
+    navigate(0)
   }
-
-  const fetch = async (id: string) => {
-    try {
-      const response = await getStateOfAgreement(id)
-      if (response.status < 400) {
-        setIsConsented(response.data)
-      }
-      if (response.status >= 400) {
-        setIsConsented(false)
-      }
-    } catch (error) {
-      console.log(error)
-    }
-  }
-
-  useEffect(() => {
-    fetch(petitionId)
-  }, [petitionId])
-
-  const { isOpen, onOpen, onClose } = useDisclosure()
 
   return (
     <SAgreementForm>
       <span>{input.description.length}/100</span>
       <form onSubmit={handleSubmit}>
         <FormControl>
-          <div className="wrapper">
-            <textarea
-              placeholder="동의합니다."
-              onChange={handleChange}
-              value={input.description}
-              maxLength={100}
-            />
-            <button
-              className="agreement_btn"
-              disabled={isConsented}
-              type="submit"
-            >
-              {!isConsented ? '동의하기' : '동의완료'}
-            </button>
-          </div>
+          {isAuthorized ? (
+            <div className="wrapper">
+              <textarea
+                placeholder={isConsented ? '동의했습니다' : '동의합니다'}
+                onChange={handleChange}
+                value={input.description}
+                maxLength={100}
+                disabled={isConsented}
+              />
+              <button
+                className="agreement_btn"
+                disabled={isConsented}
+                type="submit"
+              >
+                {!isConsented ? '동의하기' : '동의완료'}
+              </button>
+            </div>
+          ) : (
+            <div className="needLogin" onClick={_e => navigate('/login')}>
+              동의하려면&nbsp;<span>로그인</span>&nbsp;해주세요
+            </div>
+          )}
         </FormControl>
       </form>
-      <NeedLoginModal disclosure={{ isOpen, onClose }}></NeedLoginModal>
     </SAgreementForm>
   )
 }

--- a/src/pages/Petition/PetitionContents/AgreementForm/styles.ts
+++ b/src/pages/Petition/PetitionContents/AgreementForm/styles.ts
@@ -11,10 +11,27 @@ const SAgreementForm = styled.div`
     color: #8a8a8a;
     font-weight: 300;
   }
+  .needLogin {
+    display: flex;
+    height: 60px;
+    border: 1px solid #ccc;
+    font-size: 0.875rem;
+    resize: none;
+    box-sizing: border-box;
+    width: 100%auto;
+    padding: 0.6rem;
+    color: '#ccc';
+    cursor: pointer;
+
+    > span {
+      text-decoration: underline;
+    }
+  }
 
   .wrapper {
     display: flex;
     height: 60px;
+
     textarea {
       border-radius: 0;
       border: 1px solid #ccc;
@@ -23,9 +40,12 @@ const SAgreementForm = styled.div`
       box-sizing: border-box;
       width: 100%;
       padding: 0.6rem;
-
       :focus {
         outline: none;
+      }
+      > span {
+        color: red;
+        text-decoration: underline;
       }
     }
     .agreement_btn {

--- a/src/pages/Petition/PetitionContents/AgreementList/index.tsx
+++ b/src/pages/Petition/PetitionContents/AgreementList/index.tsx
@@ -13,27 +13,23 @@ import {
 } from '@ajna/pagination'
 
 import { getDayTime } from '@utils/getTime'
+import { useLocation, useNavigate } from 'react-router-dom'
 interface IProps {
-  petitionId: string
-  totalAgreement: number | undefined
+  totalAgreement: number
+  totalPages: number
+  agreements: Agreement[]
 }
 
-const AgreementList = ({ petitionId, totalAgreement }: IProps): JSX.Element => {
+const AgreementList = ({
+  totalAgreement,
+  totalPages,
+  agreements,
+}: IProps): JSX.Element => {
   const queryParams: any = qs.parse(location.search, {
     ignoreQueryPrefix: true,
   })
 
-  const [totalPages, setTotalPages] = useState<number>(0)
-  const [response, setResponse] = useState<Array<GetAgreements>>([])
-  const fetch = async (petitionId: any, queryParams: any) => {
-    try {
-      const response = await getAgreements(petitionId, queryParams)
-      setResponse(response?.data?.content || [])
-      setTotalPages(response?.data?.totalPages)
-    } catch (error) {
-      console.log(error)
-    }
-  }
+  const { search } = useLocation()
 
   const { currentPage, setCurrentPage, pagesCount, pages } = usePagination({
     pagesCount: totalPages,
@@ -46,23 +42,23 @@ const AgreementList = ({ petitionId, totalAgreement }: IProps): JSX.Element => {
     },
   })
 
+  const navigate = useNavigate()
   const handlePageChange = (e: number) => {
-    setCurrentPage(e)
     const newSearchParams = {
       ...queryParams,
       page: e,
     }
-    fetch(petitionId, newSearchParams)
+    setCurrentPage(e)
+    navigate({
+      pathname: location.pathname,
+      search: qs.stringify(newSearchParams),
+    })
   }
-
-  useEffect(() => {
-    fetch(petitionId, queryParams)
-  }, [petitionId])
 
   return (
     <CommentList>
       <ul>
-        {response.map((res, index) => (
+        {agreements.map((res, index) => (
           <li key={res.id}>
             <div className="comment">
               <div>

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -90,131 +90,63 @@ const PetitionContents = ({
   return (
     <>
       {petition?.message !== undefined ? (
-        <PetitionTitleWrap>
-          <PetitionTitle ml={'20px'} mr={'20px'}>
-            {petition?.message}
-          </PetitionTitle>
-        </PetitionTitleWrap>
+        <HeadSection>
+          <div className="title">
+            <div>{petition?.message}</div>
+          </div>
+        </HeadSection>
       ) : (
         <>
-          <Stack spacing={6} color={'#333'}>
-            <PetitionProgress>
-              <Text fontWeight={'bold'} display={'inline-block'}>
-                {petition?.answered
-                  ? '답변완료'
-                  : petition?.expired
-                  ? '청원기간만료'
-                  : petition?.released
-                  ? '청원진행중'
-                  : '사전동의진행중'}
-                &nbsp;
-              </Text>
-              <Text display={'inline'}>
-                ({getDay(Number(petition?.createdAt))}~
-                {getDay(Number(petition?.createdAt) + 2592000000)})
-              </Text>
-            </PetitionProgress>
-            <PetitionTitleWrap>
-              <PetitionTitle ml={'20px'} mr={'20px'}>
-                {petition?.title}
-              </PetitionTitle>
-            </PetitionTitleWrap>
-            <CurrentAgreementsText>
-              <Text>
-                총 <CurrentAgreements>{petition?.agreements}</CurrentAgreements>
-                명이 동의했습니다.
-              </Text>
-            </CurrentAgreementsText>
-          </Stack>
-          <Stack color={'#333'} mt={'20px'} mb={'20px'} spacing={4}>
-            <Text fontSize={'20px'} fontWeight={'bold'} align={'left'}>
-              청원내용
-            </Text>
-            <Divider color={'#ccc'}></Divider>
-            <div>
-              <ContentWrap>
-                <PetitionDescription>
-                  {petition?.description}
-                </PetitionDescription>
-              </ContentWrap>
-            </div>
-          </Stack>
-          {petition?.answered ? (
-            <Stack color={'#333'} mt={'20px'} mb={'20px'} spacing={4}>
-              <Text fontSize={'20px'} fontWeight={'bold'} align={'left'}>
-                답변
-              </Text>
-              <Divider color={'#ccc'}></Divider>
-              <div>
-                <ContentWrap>
-                  <PetitionDescription>{answer?.content}</PetitionDescription>
-                </ContentWrap>
+          <HeadSection>
+            <Stack spacing={6}>
+              <div className="info">
+                <span className="progress">
+                  {petition?.answered
+                    ? '답변완료'
+                    : petition?.expired
+                    ? '청원기간만료'
+                    : petition?.released
+                    ? '청원진행중'
+                    : '사전동의진행중'}
+                  &nbsp;
+                </span>
+                <span className="duration">
+                  ({getDay(Number(petition?.createdAt))}~
+                  {getDay(Number(petition?.createdAt) + 2592000000)})
+                </span>
+              </div>
+              <div className="title">
+                <div>{petition?.title}</div>
+              </div>
+              <div className="current_agree">
+                <span className="num_of_agree">
+                  총 <span>{petition?.agreements}</span>
+                  명이 동의했습니다.
+                </span>
               </div>
             </Stack>
-          ) : (
-            <div>
-              <SharingPetition>
-                <div className="share-btns">
-                  <div>공유하기</div>
-                  <ul className="sns">
-                    <li className="kakaotalk">
-                      <a
-                        href="#n"
-                        id="btnKakao"
-                        onClick={() => {
-                          share('kakaotalk')
-                          return false
-                        }}
-                        className="kakaotalk"
-                        target="_self"
-                        title="카카오톡 새창열림"
-                      >
-                        <RiKakaoTalkFill />
-                      </a>
-                    </li>
-                    <li className="facebook">
-                      <a
-                        href="#n"
-                        onClick={() => {
-                          share('facebook')
-                          return false
-                        }}
-                        className="facebook"
-                        target="_self"
-                        title="페이스북 새창열림"
-                      >
-                        <RiFacebookFill />
-                      </a>
-                    </li>
-                  </ul>
+          </HeadSection>
+          <DescriptionSection>
+            <Stack spacing={4}>
+              <span>청원내용</span>
+              <Divider color={'#ccc'}></Divider>
+              <div>
+                <div className="content">
+                  <div className="description">{petition?.description}</div>
                 </div>
-                <div className="share-url">
-                  <div className="url-box">
-                    <div>URL</div>
-                    <div className="url">{location.href}</div>
-                  </div>
-                  <div className="copy-btn">
-                    <button onClick={clip}>
-                      <IoMdAlbums />
-                    </button>
+              </div>
+            </Stack>
+          </DescriptionSection>
+          {petition?.answered && (
+            <AnswerSection>
+              <Stack spacing={4}>
+                <span>답변</span>
+                <Divider color={'#ccc'}></Divider>
+                <div>
+                  <div className="content">
+                    <div className="answer">{answer?.content}</div>
                   </div>
                 </div>
-              </SharingPetition>
-              <Stack>
-                <Text
-                  textAlign={'left'}
-                  fontWeight={'bold'}
-                  fontSize={'20px'}
-                  p={'0.5em 0'}
-                >
-                  청원동의{' '}
-                  <span style={{ color: '#FF0000' }}>
-                    {petition?.agreements}{' '}
-                  </span>
-                  명
-                </Text>
-                <AgreementForm {...agreementFormProps}></AgreementForm>
-                <AgreementList {...agreementListProps}></AgreementList>
               </Stack>
             </AnswerSection>
           )}
@@ -266,15 +198,12 @@ const PetitionContents = ({
           <AgreementsSection>
             <Stack>
               <span className="num_of_agree">
-                청원동의 <span>{response?.agreements} </span>명
+                청원동의 <span>{petition?.agreements} </span>명
               </span>
-              {!response?.expired && (
-                <AgreementForm petitionId={petitionId}></AgreementForm>
+              {!petition?.expired && (
+                <AgreementForm {...agreementFormProps}></AgreementForm>
               )}
-              <AgreementList
-                petitionId={petitionId}
-                totalAgreement={response?.agreements}
-              ></AgreementList>
+              <AgreementList {...agreementListProps} />
             </Stack>
           </AgreementsSection>
 

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -18,18 +18,39 @@ import NeedLoginModal from '@components/NeedLoginModal'
 import { getDay } from '@utils/getTime'
 import { RiKakaoTalkFill, RiFacebookFill } from 'react-icons/ri'
 import { IoMdAlbums } from 'react-icons/io'
+import { idText } from 'typescript'
 
-interface IProps {
-  petitionURL: string
-  petitionId: string
+interface Props {
+  id: string
+  petition: Petition | undefined
+  answer: Answer | undefined
+  totalPages: number
+  totalAgreement: number
+  agreements: Agreement[]
+  isConsented: boolean
 }
 
-const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
-  const [response, setResponse] = useState<Petition | undefined>()
-  const [answerContent, setAnswerContent] = useState<
-    AnswerContent | undefined
-  >()
+const PetitionContents = ({
+  id,
+  petition,
+  answer,
+  totalPages,
+  agreements,
+  totalAgreement,
+  isConsented,
+}: Props): JSX.Element => {
   const { isOpen, onClose } = useDisclosure()
+
+  const agreementListProps = {
+    totalAgreement,
+    totalPages,
+    agreements,
+  }
+
+  const agreementFormProps = {
+    id,
+    isConsented,
+  }
 
   const clip = () => {
     let url = ''
@@ -44,7 +65,7 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
   }
 
   const share = (sns: string) => {
-    const thisUrl = `https://dev.gist-petition.com/${petitionURL}`
+    const thisUrl = location.href
     if (sns == 'facebook') {
       const url =
         'http://www.facebook.com/sharer/sharer.php?u=' +
@@ -57,7 +78,7 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
         objectType: 'feed',
         content: {
           title: 'GIST 청원',
-          description: response?.title,
+          description: petition?.title,
           imageUrl:
             'https://raw.githubusercontent.com/GIST-Petition-Site-Project/GIST-petition-web-ts/develop/src/assets/img/share_img.png',
           link: {
@@ -69,22 +90,12 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
     }
   }
 
-  useEffect(() => {
-    const getPetitionInformation = async (petitionURL: string) => {
-      const response = await getPetitionById(petitionURL)
-      setResponse(response?.data)
-      const getAnswer = await getRetrieveAnswer(petitionId)
-      setAnswerContent(getAnswer?.data)
-    }
-    getPetitionInformation(petitionURL)
-  }, [petitionId])
-
   return (
     <>
-      {response?.message !== undefined ? (
+      {petition?.message !== undefined ? (
         <PetitionTitleWrap>
           <PetitionTitle ml={'20px'} mr={'20px'}>
-            {response?.message}
+            {petition?.message}
           </PetitionTitle>
         </PetitionTitleWrap>
       ) : (
@@ -92,21 +103,21 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
           <Stack spacing={6} color={'#333'}>
             <PetitionProgress>
               <Text fontWeight={'bold'} display={'inline-block'}>
-                {!response?.answered ? '청원진행중' : '답변완료'}&nbsp;
+                {!petition?.answered ? '청원진행중' : '답변완료'}&nbsp;
               </Text>
               <Text display={'inline'}>
-                ({getDay(Number(response?.createdAt))}~
-                {getDay(Number(response?.createdAt) + 2592000000)})
+                ({getDay(Number(petition?.createdAt))}~
+                {getDay(Number(petition?.createdAt) + 2592000000)})
               </Text>
             </PetitionProgress>
             <PetitionTitleWrap>
               <PetitionTitle ml={'20px'} mr={'20px'}>
-                {response?.title}
+                {petition?.title}
               </PetitionTitle>
             </PetitionTitleWrap>
             <CurrentAgreementsText>
               <Text>
-                총 <CurrentAgreements>{response?.agreements}</CurrentAgreements>
+                총 <CurrentAgreements>{petition?.agreements}</CurrentAgreements>
                 명이 동의했습니다.
               </Text>
             </CurrentAgreementsText>
@@ -119,12 +130,12 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
             <div>
               <ContentWrap>
                 <PetitionDescription>
-                  {response?.description}
+                  {petition?.description}
                 </PetitionDescription>
               </ContentWrap>
             </div>
           </Stack>
-          {response?.answered ? (
+          {petition?.answered ? (
             <Stack color={'#333'} mt={'20px'} mb={'20px'} spacing={4}>
               <Text fontSize={'20px'} fontWeight={'bold'} align={'left'}>
                 답변
@@ -132,9 +143,7 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
               <Divider color={'#ccc'}></Divider>
               <div>
                 <ContentWrap>
-                  <PetitionDescription>
-                    {answerContent?.content}
-                  </PetitionDescription>
+                  <PetitionDescription>{answer?.content}</PetitionDescription>
                 </ContentWrap>
               </div>
             </Stack>
@@ -178,10 +187,7 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
                 <div className="share-url">
                   <div className="url-box">
                     <div>URL</div>
-                    <div className="url">
-                      https://www.gist-petition.com/
-                      {petitionURL}
-                    </div>
+                    <div className="url">{location.href}</div>
                   </div>
                   <div className="copy-btn">
                     <button onClick={clip}>
@@ -199,15 +205,12 @@ const PetitionContents = ({ petitionURL, petitionId }: IProps): JSX.Element => {
                 >
                   청원동의{' '}
                   <span style={{ color: '#FF0000' }}>
-                    {response?.agreements}{' '}
+                    {petition?.agreements}{' '}
                   </span>
                   명
                 </Text>
-                <AgreementForm petitionId={petitionId}></AgreementForm>
-                <AgreementList
-                  petitionId={petitionId}
-                  totalAgreement={response?.agreements}
-                ></AgreementList>
+                <AgreementForm {...agreementFormProps}></AgreementForm>
+                <AgreementList {...agreementListProps}></AgreementList>
               </Stack>
             </div>
           )}

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -103,11 +103,11 @@ const PetitionContents = ({
           <Stack spacing={6} color={'#333'}>
             <PetitionProgress>
               <Text fontWeight={'bold'} display={'inline-block'}>
-                {response?.answered
+                {petition?.answered
                   ? '답변완료'
-                  : response?.expired
+                  : petition?.expired
                   ? '청원기간만료'
-                  : response?.released
+                  : petition?.released
                   ? '청원진행중'
                   : '사전동의진행중'}
                 &nbsp;

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -1,5 +1,5 @@
 import { useLocation, useParams } from 'react-router'
-import { Container, PetitionWrapper } from './styles'
+import { Container } from './styles'
 import PetitionContents from './PetitionContents'
 import {
   getAgreements,
@@ -80,9 +80,9 @@ const Petition = (): JSX.Element => {
   return (
     <Container>
       <Inner>
-        <PetitionWrapper>
+        <div className="petition_wrap">
           <PetitionContents {...petitionContentsProps}></PetitionContents>
-        </PetitionWrapper>
+        </div>
       </Inner>
     </Container>
   )

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -1,33 +1,87 @@
-import { useParams } from 'react-router'
+import { useLocation, useParams } from 'react-router'
 import { Container, PetitionWrapper } from './styles'
 import PetitionContents from './PetitionContents'
-import { getPetitionById } from '@api/petitionAPI'
+import {
+  getAgreements,
+  getId,
+  getPetitionById,
+  getRetrieveAnswer,
+  getStateOfAgreement,
+} from '@api/petitionAPI'
 import { useEffect, useState } from 'react'
 
 import Inner from '@components/Inner'
+import qs from 'qs'
 
 const Petition = (): JSX.Element => {
-  const { id } = useParams()
-  const [petitionId, setPetitionId] = useState<string>(String(id))
-  const petitionURL: string = location.pathname.slice(1)
-  const getPetitionId = async (petitionURL: string) => {
-    const response = await getPetitionById(petitionURL)
-    if (response?.data?.id) {
-      setPetitionId(String(response?.data?.id))
+  const { param } = useParams()
+  const { search } = useLocation()
+  const queryParams: any = qs.parse(location.search, {
+    ignoreQueryPrefix: true,
+  })
+
+  const [id, setId] = useState('')
+  const [petition, setPetition] = useState<Petition>()
+  const [answer, setAnswer] = useState<Answer>()
+  const [agreements, setAgreements] = useState<Agreement[]>([])
+  const [totalPages, setTotalPages] = useState(0)
+  const [totalAgreement, setTotalAgreement] = useState(0)
+  const [isConsented, setIsConsented] = useState(false)
+  const fetchPetition = async (param: string) => {
+    const id = await getId(param)
+    setId(id)
+    if (location.href.includes('temp')) {
+      const petitionResponse = await getPetitionById(`temp/${param}`)
+      setPetition(petitionResponse.data)
+    } else {
+      const petitionResponse = await getPetitionById(id)
+      setPetition(petitionResponse.data)
     }
+    const consentedResponse = await getStateOfAgreement(id)
+    setIsConsented(consentedResponse.data)
   }
+
   useEffect(() => {
-    getPetitionId(petitionURL)
+    fetchPetition(param as string)
   }, [])
+
+  const fetchAnswer = async () => {
+    if (!petition?.answered) return
+    const response = await getRetrieveAnswer(id)
+    setAnswer(response.data)
+  }
+
+  useEffect(() => {
+    fetchAnswer()
+  }, [petition])
+
+  const fetchAgreements = async () => {
+    if (!id) return
+    const agreementsResponse = await getAgreements(id, queryParams)
+    setAgreements(agreementsResponse?.data?.content || [])
+    setTotalPages(agreementsResponse?.data?.totalPages)
+    setTotalAgreement(agreementsResponse?.data?.totalElements)
+  }
+
+  useEffect(() => {
+    fetchAgreements()
+  }, [search, petition])
+
+  const petitionContentsProps = {
+    id,
+    petition,
+    answer,
+    agreements,
+    totalPages,
+    totalAgreement,
+    isConsented,
+  }
 
   return (
     <Container>
       <Inner>
         <PetitionWrapper>
-          <PetitionContents
-            petitionURL={petitionURL}
-            petitionId={petitionId}
-          ></PetitionContents>
+          <PetitionContents {...petitionContentsProps}></PetitionContents>
         </PetitionWrapper>
       </Inner>
     </Container>

--- a/src/route/RootRouter.tsx
+++ b/src/route/RootRouter.tsx
@@ -28,10 +28,10 @@ const RootRouter = (): JSX.Element => {
         </Route>
         <Route path="/petitions" element={<Outlet />}>
           <Route index element={<Petitions />} />
-          <Route path=":petitionId" element={<Petition />} />
+          <Route path=":param" element={<Petition />} />
         </Route>
         <Route path="/petitions/temp" element={<Outlet />}>
-          <Route path=":id" element={<Petition />} />
+          <Route path=":param" element={<Petition />} />
         </Route>
         <Route path="/mypetitions" element={<AuthRoute />}>
           <Route index element={<MyPetitions />} />

--- a/src/types/answer.d.ts
+++ b/src/types/answer.d.ts
@@ -1,4 +1,4 @@
-interface AnswerContent {
+interface Answer {
   content: string
   createdAt: string
   id: number

--- a/src/types/petition.d.ts
+++ b/src/types/petition.d.ts
@@ -38,7 +38,7 @@ interface AgreePetition {
   description: string
 }
 
-interface GetAgreements {
+interface Agreement {
   description: string
   id: number
   createdAt: number

--- a/src/utils/api/petitionAPI.ts
+++ b/src/utils/api/petitionAPI.ts
@@ -1,13 +1,23 @@
 import api from './baseAPI'
 import qs from 'qs'
 
+const isTempURL = () => {
+  return location.pathname.includes('temp')
+}
+
+export const getId = async (param: string) => {
+  if (location.pathname.includes('temp')) {
+    const response = await api.get(`petitions/temp/${param}`)
+    return response.data.id
+  } else return param
+}
+
 export const getPetitionsByQuery = async (query: QueryParams) => {
   const page = (Number(query?.page) || 1) - 1
   const querystring = {
     ...query,
     page,
   }
-
   const response = await api.get(
     `petitions/ongoing?${qs.stringify(querystring)}`,
   )
@@ -34,29 +44,23 @@ export const getMineByQuery = async (query: QueryParams) => {
   return response
 }
 
-export const getAgreementCount = async (petitionId: string) => {
-  if (petitionId.length === 6 || petitionId === 'undefined')
-    return { status: 500 }
-  const response = await api.get(`petitions/${petitionId}/agreements`)
+export const getAgreementCount = async (param: string) => {
+  const id = await getId(param)
+  const response = await api.get(`petitions/${id}/agreements`)
   return response
 }
 
-export const getAgreements = async (petitionId: string, query: QueryParams) => {
-  if (petitionId.length === 6 || petitionId === 'undefined')
-    return {
-      status: 500,
-      data: null,
-    }
+export const getAgreements = async (id: string, query: QueryParams) => {
   const size = Number(query?.size) || 10
   const page = Number(query?.page) - 1 || 0
   const response = await api.get(
-    `petitions/${petitionId}/agreements?size=${size}&page=${page}`,
+    `petitions/${id}/agreements?size=${size}&page=${page}`,
   )
   return response
 }
 
-export const getPetitionById = async (petitionId: string) => {
-  const response = await api.get(petitionId)
+export const getPetitionById = async (id: string) => {
+  const response = await api.get(`/petitions/${id}`)
   return response
 }
 
@@ -65,20 +69,13 @@ export const getPetitionCount = async () => {
   return response
 }
 
-export const getStateOfAgreement = async (petitionId: string) => {
-  if (petitionId.length === 6 || petitionId === 'undefined')
-    return { status: 500, data: true }
-  const response = await api.get(`petitions/${petitionId}/agreements/me`)
+export const getStateOfAgreement = async (id: string) => {
+  const response = await api.get(`petitions/${id}/agreements/me`)
   return response
 }
 
-export const postAgreePetition = async (
-  petitionId: string,
-  payload: AgreePetition,
-) => {
-  if (petitionId.length === 6 || petitionId === 'undefined')
-    return { status: 500 }
-  const response = await api.post(`petitions/${petitionId}/agreements`, payload)
+export const postAgreePetition = async (id: string, payload: AgreePetition) => {
+  const response = await api.post(`petitions/${id}/agreements`, payload)
   return response
 }
 
@@ -88,8 +85,6 @@ export const postCreatePetition = async (payload: PetitionsInput) => {
 }
 
 export const getRetrieveAnswer = async (petitionId: string) => {
-  if (petitionId.length === 6 || petitionId === 'undefined')
-    return { status: 500, data: null }
   const response = await api.get(`petitions/${petitionId}/answer`)
   return response
 }


### PR DESCRIPTION
## 개요

내용을 요약해주세요.

## 미리보기

<img width="1024" alt="image" src="https://user-images.githubusercontent.com/63437430/156204817-7562a9c3-5398-423d-a600-778ffb83887f.png">

## 상세 설명

로그인 안한 상태에서 동의하기 버튼과 로그인을 위한 모달창을 띄우는 대신 로그인을 요청하는 링크로 대체했습니다.

tempUrl(사전 동의 6개 영문자), id(숫자) 를 기준으로 설명할게요.

기존 petition 컴포넌트는 사전 동의중인 청원의 동의 목록이나, 여러 정보를 가져오기 위해 petition의 id(숫자)를 확인해야했습니다. 

즉 사전 동의중인 청원은 peition 정보만 id를 통한 접근을 제한했기 때문에 해당 청원과 연결된 나머지 API 들은 id 를 통해 요청을 보내야 합니다.

기존 구현 방식은 API 단에서 6자리 문자열인 경우에 tempUrl로 처리하여 요청을 보내지 않고 바로 return 해주는 방식을 이용했었는데, 이러한 방식은 return 타입이 달라질 뿐만 아니라 추후 100년쯤 뒤 저희 서비스에 10만건의 청원이 쌓이면 문제가 발생합니다.  (사실 그게 아니더라도 문제가 많은 코드입니다,,)

처음 사전 동의 기능이 도입되었을때 기존 구현을 그대로 이용하려다 보니 이런 잘못된 코드를 작성했는데 이번 기회에 바로잡고자 노력했습니다. 

변경된 방식은 Petition/index.tsx 컴포넌트에서 모든 요청을 처리하고 그 결과 상태를 하위 컴포넌트에 전해주도록 리팩토링 하였습니다.

자세한 설명은 코드 변경 기록에 코맨트를 달아놓도록 하겠습니다!

## 기타

Close #278
