### PR TITLE
fix: url에 동의 코멘트 페이지네이션을 위한 쿼리스트링이 붙는 문제 해결

### DIFF
--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -59,7 +59,6 @@ const PetitionContents = ({
   }
 
   const share = (sns: string) => {
-    console.log(sharingURL)
     if (sns == 'facebook') {
       const url =
         'http://www.facebook.com/sharer/sharer.php?u=' +

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -8,7 +8,6 @@ import {
 } from './styles'
 import AgreementList from './AgreementList'
 import AgreementForm from './AgreementForm'
-import { useDisclosure } from '@chakra-ui/react'
 import { getDay } from '@utils/getTime'
 import { RiKakaoTalkFill, RiFacebookFill } from 'react-icons/ri'
 import { IoMdAlbums } from 'react-icons/io'
@@ -33,6 +32,11 @@ const PetitionContents = ({
   totalAgreement,
   isConsented,
 }: Props): JSX.Element => {
+  const sharingURL =
+    process.env.NODE_ENV === 'development'
+      ? 'https://dev.gist-petition.com' + location.pathname
+      : location.origin + location.pathname
+
   const agreementListProps = {
     totalAgreement,
     totalPages,
@@ -47,7 +51,7 @@ const PetitionContents = ({
   const clip = () => {
     const textarea = document.createElement('textarea')
     document.body.appendChild(textarea)
-    textarea.value = String(location)
+    textarea.value = String(location.origin + location.pathname)
     textarea.select()
     document.execCommand('copy')
     document.body.removeChild(textarea)
@@ -55,11 +59,11 @@ const PetitionContents = ({
   }
 
   const share = (sns: string) => {
-    const thisUrl = location.href
+    console.log(sharingURL)
     if (sns == 'facebook') {
       const url =
         'http://www.facebook.com/sharer/sharer.php?u=' +
-        encodeURIComponent(thisUrl)
+        encodeURIComponent(sharingURL)
       window.open(url, '', 'width=256, height=512')
     } else if (sns == 'kakaotalk') {
       if (!window.Kakao.isInitialized()) {
@@ -74,8 +78,8 @@ const PetitionContents = ({
           imageUrl:
             'https://raw.githubusercontent.com/GIST-Petition-Site-Project/GIST-petition-web-ts/develop/src/assets/img/share_img.png',
           link: {
-            mobileWebUrl: thisUrl,
-            webUrl: thisUrl,
+            mobileWebUrl: sharingURL,
+            webUrl: sharingURL,
           },
         },
       })
@@ -181,7 +185,7 @@ const PetitionContents = ({
             <div className="share-url">
               <div className="url-box">
                 <div>URL</div>
-                <div className="url">{String(location)}</div>
+                <div className="url">{sharingURL}</div>
               </div>
               <div className="copy-btn">
                 <button onClick={clip}>


### PR DESCRIPTION
## 개요

공유 url 에 페이지네이션을 위한 쿼리스트링이 포함되는 것을 수정했습니다.

## 미리보기

<img width="1174" alt="image" src="https://user-images.githubusercontent.com/63437430/156575641-e9c36f0d-505a-43af-970e-1fb8020ce248.png">

## 상세 내용

location.origin + location.pathname 을 이용하여 쿼리스트링을 땠습니다.

Close #285 
