### PR TITLE
Design/animation

### DIFF
--- a/src/components/PetitionList/index.tsx
+++ b/src/components/PetitionList/index.tsx
@@ -1,5 +1,5 @@
 import qs from 'qs'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, Outlet } from 'react-router-dom'
 import { getDay } from '@utils/getTime'
 
@@ -15,8 +15,18 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
     setPetitionList(response?.data?.content)
   }
 
+  const progress = useRef<string>(
+    getPetitions.name === 'getPetitionsByQuery'
+      ? '진행중인'
+      : getPetitions.name === 'getExpiredByQuery'
+      ? '만료된'
+      : getPetitions.name === 'getAnsweredByQuery'
+      ? '답변된'
+      : '',
+  )
+
   const [petitionList, setPetitionList] = useState<Array<Petition>>([])
-  console.log(petitionList)
+
   useEffect(() => {
     queryPost(queryParams)
   }, [location.search])
@@ -33,22 +43,30 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
       </PetitionsHead>
 
       <PetitionsUl className="petition_list">
-        {petitionList.map(petition => (
-          <li key={petition.id}>
-            <div className="category">{petition.categoryName}</div>
-            <div className="subject">
-              <Link to={`/petitions/${petition.id}`}>{petition.title}</Link>
-            </div>
-            <div className="date">
-              {getDay(petition.createdAt)} ~{' '}
-              {getDay(petition.createdAt + 2592000000)}
-            </div>
-            <div className="agreements">
-              {petition.agreements}
-              <span>명</span>
-            </div>
-          </li>
-        ))}
+        {petitionList.length === 0 ? (
+          <div className="empty_message">
+            <span>{progress.current} 청원이 없습니다.</span>
+          </div>
+        ) : (
+          <>
+            {petitionList.map(petition => (
+              <li key={petition.id}>
+                <div className="category">{petition.categoryName}</div>
+                <div className="subject">
+                  <Link to={`/petitions/${petition.id}`}>{petition.title}</Link>
+                </div>
+                <div className="date">
+                  {getDay(petition.createdAt)} ~{' '}
+                  {getDay(petition.createdAt + 2592000000)}
+                </div>
+                <div className="agreements">
+                  {petition.agreements}
+                  <span>명</span>
+                </div>
+              </li>
+            ))}
+          </>
+        )}
       </PetitionsUl>
       <Outlet />
     </>

--- a/src/components/PetitionList/index.tsx
+++ b/src/components/PetitionList/index.tsx
@@ -16,7 +16,7 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
   }
 
   const [petitionList, setPetitionList] = useState<Array<Petition>>([])
-
+  console.log(petitionList)
   useEffect(() => {
     queryPost(queryParams)
   }, [location.search])

--- a/src/components/PetitionList/styles.ts
+++ b/src/components/PetitionList/styles.ts
@@ -45,6 +45,13 @@ const PetitionsHead = styled.div`
 const PetitionsUl = styled.ul`
   margin-left: 0;
 
+  .empty_message {
+    margin: 12em 0;
+    span {
+      font-size: 1.2em;
+      font-weight: 600;
+    }
+  }
   li {
     position: relative;
     padding: 20px 0;

--- a/src/pages/Home/Banner/styles.ts
+++ b/src/pages/Home/Banner/styles.ts
@@ -6,27 +6,21 @@ import { keyframes } from '@emotion/react'
 const firstRowIn = keyframes`
   0% {
     opacity: 0;
-    transform: translateY(20px);
   }
   100% {
     opacity: 1;
-    transform: translateY(0);
   }
 `
 
 const secondRowIn = keyframes`
   0% {
     opacity: 0;
-    transform: translateY(20px);
   }
-
   50%{
     opacity: 0;
-    transform: translateY(20px);
   }
   100% {
     opacity: 1;
-    transform: translateY(0);
   }
 `
 

--- a/src/pages/MyPetitions/MyPetitionList/index.tsx
+++ b/src/pages/MyPetitions/MyPetitionList/index.tsx
@@ -1,5 +1,5 @@
 import qs from 'qs'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Link, Outlet } from 'react-router-dom'
 import { getDay } from '@utils/getTime'
 
@@ -33,39 +33,50 @@ const MyPetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
       </PetitionsHead>
 
       <PetitionsUl className="petition_list">
-        {petitionList.map(petition => (
-          <li key={petition.id}>
-            <Status
-              className="status"
-              isAnswered={petition.answered}
-              isExpired={petition.expired}
-            >
-              <div className="status_box">
-                {petition.answered
-                  ? '답변완료'
-                  : petition.expired
-                  ? '청원기간만료'
-                  : petition.released
-                  ? '청원진행중'
-                  : '사전동의진행중'}
-              </div>
-            </Status>
-            <div className="category">{petition.categoryName}</div>
-            <div className="subject">
-              <Link to={`/petitions/temp/${petition.tempUrl}`}>
-                {petition.title}
-              </Link>
-            </div>
-            <div className="date">
-              {getDay(petition.createdAt)} ~{' '}
-              {getDay(petition.createdAt + 2592000000)}
-            </div>
-            <div className="agreements">
-              {petition.agreements}
-              <span>명</span>
-            </div>
-          </li>
-        ))}
+        {petitionList.length === 0 ? (
+          <div className="empty_message">
+            <span>나의 청원이 없습니다.</span>
+            <br />
+            <br />
+            <span>청원을 등록해주세요!</span>
+          </div>
+        ) : (
+          <>
+            {petitionList.map(petition => (
+              <li key={petition.id}>
+                <Status
+                  className="status"
+                  isAnswered={petition.answered}
+                  isExpired={petition.expired}
+                >
+                  <div className="status_box">
+                    {petition.answered
+                      ? '답변완료'
+                      : petition.expired
+                      ? '청원기간만료'
+                      : petition.released
+                      ? '청원진행중'
+                      : '사전동의진행중'}
+                  </div>
+                </Status>
+                <div className="category">{petition.categoryName}</div>
+                <div className="subject">
+                  <Link to={`/petitions/temp/${petition.tempUrl}`}>
+                    {petition.title}
+                  </Link>
+                </div>
+                <div className="date">
+                  {getDay(petition.createdAt)} ~{' '}
+                  {getDay(petition.createdAt + 2592000000)}
+                </div>
+                <div className="agreements">
+                  {petition.agreements}
+                  <span>명</span>
+                </div>
+              </li>
+            ))}
+          </>
+        )}
       </PetitionsUl>
       <Outlet />
     </>

--- a/src/pages/MyPetitions/MyPetitionList/styles.ts
+++ b/src/pages/MyPetitions/MyPetitionList/styles.ts
@@ -56,7 +56,15 @@ const PetitionsHead = styled.div`
 
 const PetitionsUl = styled.ul`
   margin-left: 0;
-  min-height: 570px;
+
+  .empty_message {
+    margin: 12em 0;
+    text-align: center;
+    span {
+      font-size: 1.2em;
+      font-weight: 600;
+    }
+  }
 
   li {
     position: relative;

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react'
+import { ChangeEvent, useMemo, useState } from 'react'
 import {
   Select,
   Tabs,
@@ -21,13 +21,16 @@ const Petitions = (): JSX.Element => {
     ignoreQueryPrefix: true,
   })
 
-  const numberOfCategory = Object.keys(Category).filter(el =>
-    isNaN(Number(el)),
-  ).length
+  const countCategoryIdx = useMemo(() => {
+    const numberOfCategory =
+      Object.keys(Category).filter(el => isNaN(Number(el))).length - 1
 
-  const catergoryIdx = Array(numberOfCategory)
-    .fill(0)
-    .map((_x, i) => i)
+    const catergoryIdx = Array(numberOfCategory)
+      .fill(0)
+      .map((_x, i) => i + 1)
+
+    return catergoryIdx
+  }, [])
 
   const [sortSelected, setSortSelected] = useState<string>(
     queryParams?.sort || '',
@@ -89,7 +92,7 @@ const Petitions = (): JSX.Element => {
                 <option value={'createdAt,asc'}>만료임박순</option>
               </Select>
               <Select onChange={handleCategorySelect} value={categorySelected}>
-                {catergoryIdx.map(item => (
+                {countCategoryIdx.map(item => (
                   <option value={item} key={item}>
                     {Category[item]}
                   </option>

--- a/src/pages/Petitions/index.tsx
+++ b/src/pages/Petitions/index.tsx
@@ -22,12 +22,13 @@ const Petitions = (): JSX.Element => {
   })
 
   const countCategoryIdx = useMemo(() => {
-    const numberOfCategory =
-      Object.keys(Category).filter(el => isNaN(Number(el))).length - 1
+    const numberOfCategory = Object.keys(Category).filter(el =>
+      isNaN(Number(el)),
+    ).length
 
     const catergoryIdx = Array(numberOfCategory)
       .fill(0)
-      .map((_x, i) => i + 1)
+      .map((_x, i) => i)
 
     return catergoryIdx
   }, [])


### PR DESCRIPTION
## 개요

- 메인 대쉬보드 애니메이션에서 translateY를 빼고 opacity만 주었습니다. (제안)
- petitions 페이지 역시 useMemo로 카테고리 연산 로직을 한번만 수행할 수 있게 만들었습니다.
- petitions에서 실수로 전체 카테고리를 뺐는데, 다시 전체 카테고리를 선택할 수 있게 만들었습니다.
- 이젠 등록된 청원이 없다면 메세지를 표시해줍니다.
"진행중인/만료된/답변된/나의 청원이 없습니다."

## 미리보기

<img width="952" alt="스크린샷 2022-03-13 오후 7 46 30" src="https://user-images.githubusercontent.com/65757344/158055933-89a28cd4-cb5a-4704-937c-52284582b6eb.png">


## 기타

Close #235 
