### PR TITLE
design: 모바일 뷰 - border 없애기 & 대쉬보드 수직 중앙 정렬

### DIFF
--- a/src/pages/Home/Banner/styles.ts
+++ b/src/pages/Home/Banner/styles.ts
@@ -47,7 +47,7 @@ const BannerSection = styled.section`
       position: absolute;
       display: flex;
       margin: auto;
-      height: 88px;
+      height: 72px;
       flex-direction: column;
       font-weight: bold;
       color: ${theme.color.WHITE};
@@ -55,7 +55,7 @@ const BannerSection = styled.section`
       letter-spacing: 0.1em;
       text-align: center;
       bottom: 0;
-      top: 0;
+      top: 59px;
       left: 0;
       right: 0;
       font-size: 1.5rem;

--- a/src/pages/Petition/styles.ts
+++ b/src/pages/Petition/styles.ts
@@ -9,11 +9,11 @@ const Container = styled.div`
     }
 
     .petition_wrap {
-      border: 1px solid #ccc;
       position: relative;
       margin: 6rem 0 50px 0;
-      padding: 30px 1.5rem;
+      padding: 0 1rem 30px;
       @media screen and (min-width: ${theme.breakpoints.md}) {
+        border: 1px solid #ccc;
         padding: 50px 30px;
       }
     }

--- a/src/pages/Write/styles.ts
+++ b/src/pages/Write/styles.ts
@@ -18,8 +18,10 @@ const Container = styled.div`
 `
 
 const WriteContainer = styled.div`
-  border: 1px solid #ccc;
-  border-radius: 0;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    border: 1px solid #ccc;
+    border-radius: 0;
+  }
   .write_wrapper {
     margin: 1rem;
     @media screen and (min-width: ${theme.breakpoints.md}) {


### PR DESCRIPTION
## 개요

모바일 뷰

1. 청원 작성 & 청원 보기 페이지에서 border를 없애고 청원 보기의 padding top도 없앴습니다.
2. 메인 페이지 대쉬보드 글씨를 수직 중앙정렬 시켜놨습니다.

## 미리보기

1. border 없애기
<img width="384" alt="스크린샷 2022-03-13 오후 8 40 48" src="https://user-images.githubusercontent.com/65757344/158057689-f635cea5-85f9-4284-875e-4a5d0de86e6b.png">

3. 대쉬보드 글씨 수직 중앙 정렬
<img width="411" alt="스크린샷 2022-03-13 오후 8 40 24" src="https://user-images.githubusercontent.com/65757344/158057671-a25ea0a2-4899-4b8e-a6f9-e03a4128f425.png">


## 기타

Close #301 
