### PR TITLE
feat: answer api 수정 & 카카오톡 공유 제목/글 보이게 설정

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,16 +5,16 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="GIST 청원" />
+    <meta name="description" content="지스트 청원" />
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="GIST 청원" />
-    <meta property="og:title" content="GIST 청원" />
+    <meta property="og:site_name" content="지스트 청원" />
+    <meta property="og:title" content="지스트 청원" />
     <meta
       property="og:description"
       content="학교에 나의 의견을 공식적으로 건의하자!"
     />
-    <meta property="og:image" content="../assets/img/logo_light.png" />
-    <meta property="og:url" content="https://dev.gist-petition.com" />
+    <meta property="og:image" content="../src/assets/img/new_logo_black.svg" />
+    <meta property="og:url" content="https://www.gist-petition.com" />
 
     <link
       rel="stylesheet"
@@ -22,7 +22,7 @@
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>GIST 청원</title>
+    <title>지스트 청원</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -11,12 +11,11 @@ import AgreementForm from './AgreementForm'
 import { getDay } from '@utils/getTime'
 import { RiKakaoTalkFill, RiFacebookFill } from 'react-icons/ri'
 import { IoMdAlbums } from 'react-icons/io'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 
-interface Props {
+interface IProps {
   id: string
   petition: Petition | undefined
-  answer: Answer | undefined
   totalPages: number
   totalAgreement: number
   agreements: Agreement[]
@@ -26,16 +25,16 @@ interface Props {
 const PetitionContents = ({
   id,
   petition,
-  answer,
   totalPages,
   agreements,
   totalAgreement,
   isConsented,
-}: Props): JSX.Element => {
-  const sharingURL =
+}: IProps): JSX.Element => {
+  const sharingURL = useRef<string>(
     process.env.NODE_ENV === 'development'
       ? 'https://dev.gist-petition.com' + location.pathname
-      : location.origin + location.pathname
+      : location.origin + location.pathname,
+  )
 
   const agreementListProps = {
     totalAgreement,
@@ -62,7 +61,7 @@ const PetitionContents = ({
     if (sns == 'facebook') {
       const url =
         'http://www.facebook.com/sharer/sharer.php?u=' +
-        encodeURIComponent(sharingURL)
+        encodeURIComponent(sharingURL.current)
       window.open(url, '', 'width=256, height=512')
     } else if (sns == 'kakaotalk') {
       if (!window.Kakao.isInitialized()) {
@@ -72,13 +71,13 @@ const PetitionContents = ({
         container: '#btnKakao',
         objectType: 'feed',
         content: {
-          title: petition?.title || 'GIST 청원',
-          description: petition?.description || '',
+          title: petition?.title,
+          description: petition?.description,
           imageUrl:
             'https://raw.githubusercontent.com/GIST-Petition-Site-Project/GIST-petition-web-ts/develop/src/assets/img/share_img.png',
           link: {
-            mobileWebUrl: sharingURL,
-            webUrl: sharingURL,
+            mobileWebUrl: sharingURL.current,
+            webUrl: sharingURL.current,
           },
         },
       })
@@ -86,8 +85,10 @@ const PetitionContents = ({
   }
 
   useEffect(() => {
-    share('kakaotalk')
-  }, [])
+    if (petition) {
+      share('kakaotalk')
+    }
+  }, [petition])
 
   return (
     <>
@@ -146,7 +147,7 @@ const PetitionContents = ({
                 <Divider color={'#ccc'}></Divider>
                 <div>
                   <div className="content">
-                    <div className="answer">{answer?.content}</div>
+                    <div className="answer">{petition?.answer}</div>
                   </div>
                 </div>
               </Stack>
@@ -184,7 +185,7 @@ const PetitionContents = ({
             <div className="share-url">
               <div className="url-box">
                 <div>URL</div>
-                <div className="url">{sharingURL}</div>
+                <div className="url">{sharingURL.current}</div>
               </div>
               <div className="copy-btn">
                 <button onClick={clip}>

--- a/src/pages/Petition/index.tsx
+++ b/src/pages/Petition/index.tsx
@@ -5,7 +5,6 @@ import {
   getAgreements,
   getId,
   getPetitionById,
-  getRetrieveAnswer,
   getStateOfAgreement,
 } from '@api/petitionAPI'
 import { useEffect, useState } from 'react'
@@ -22,7 +21,6 @@ const Petition = (): JSX.Element => {
 
   const [id, setId] = useState('')
   const [petition, setPetition] = useState<Petition>()
-  const [answer, setAnswer] = useState<Answer>()
   const [agreements, setAgreements] = useState<Agreement[]>([])
   const [totalPages, setTotalPages] = useState(0)
   const [totalAgreement, setTotalAgreement] = useState(0)
@@ -45,16 +43,6 @@ const Petition = (): JSX.Element => {
     fetchPetition(param as string)
   }, [])
 
-  const fetchAnswer = async () => {
-    if (!petition?.answered) return
-    const response = await getRetrieveAnswer(id)
-    setAnswer(response.data)
-  }
-
-  useEffect(() => {
-    fetchAnswer()
-  }, [petition])
-
   const fetchAgreements = async () => {
     if (!id) return
     const agreementsResponse = await getAgreements(id, queryParams)
@@ -70,7 +58,6 @@ const Petition = (): JSX.Element => {
   const petitionContentsProps = {
     id,
     petition,
-    answer,
     agreements,
     totalPages,
     totalAgreement,

--- a/src/types/petition.d.ts
+++ b/src/types/petition.d.ts
@@ -1,16 +1,16 @@
 interface Petition {
   agreements: number
+  answer: string
   answered: boolean
-  expired: boolean
-  released: boolean
   categoryName: string
   createdAt: number
   description: string
+  expired: boolean
   id: number
+  released: boolean
+  tempUrl: string
   title: string
   updatedAt: number
-  userId: number
-  tempUrl: string
   message: string
 }
 

--- a/src/utils/api/petitionAPI.ts
+++ b/src/utils/api/petitionAPI.ts
@@ -89,11 +89,6 @@ export const postCreatePetition = async (payload: PetitionsInput) => {
   return response
 }
 
-export const getRetrieveAnswer = async (petitionId: string) => {
-  const response = await api.get(`petitions/${petitionId}/answer`)
-  return response
-}
-
 export const getAnsweredByQuery = async (query: QueryParams) => {
   const page = (Number(query?.page) || 1) - 1
   const querystring = {


### PR DESCRIPTION
## 개요

- answer api 수정된 것을 반영했습니다. 기존 getRetrieveAnswer를 삭제하였습니다.
- 카카오톡 공유시 제목과 글이 안보이던 문제를 해결했습니다.
- 사이트 공식 명칭 '지스트 청원'을 반영했습니다.
- 오픈 그래프 사진이 잘 먹히는지 테스트 해봐야합니다.
