### PR TITLE
fix: Petition의 answer 칼럼이 내용 대신 description 항목을 가지는 사항 반영

### DIFF
--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -147,7 +147,9 @@ const PetitionContents = ({
                 <Divider color={'#ccc'}></Divider>
                 <div>
                   <div className="content">
-                    <div className="answer">{petition?.answer}</div>
+                    <div className="answer">
+                      {petition?.answer?.description}
+                    </div>
                   </div>
                 </div>
               </Stack>


### PR DESCRIPTION
## 개요

Petition의 answer 칼럼이 내용 대신 description 항목을 가지는 사항 반영