### PR TITLE
fix:약관동의 에러메시지 이슈 해결

### DIFF
--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -81,6 +81,7 @@ const Register = (): JSX.Element => {
   }
 
   const handleAgreeBtn = () => {
+    console.log('hi')
     if (agreeInfo.private === true && agreeInfo.service === true) {
       setBtnUI('Agreed')
       setContentUI('Email')
@@ -161,38 +162,41 @@ const Register = (): JSX.Element => {
   // const handleRegister = async () => {
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
-    console.log('d')
-    setErrorText('')
-    const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
-    if (!passwordRegex.test(input.password)) {
-      setErrorText('영문과 숫자를 포함한 8자리 이상의 비밀번호를 설정해주세요')
-      return
-    }
-    if (input.password === input.passwordConfirm) {
-      const response = await postRegister({
-        username: input.username,
-        verificationCode: input.verificationCode,
-        password: input.password,
-      })
-      const status = response.status
-      const message = response.data.message
-      setErrorText(message)
-
-      if (status < 400) {
-        toast({
-          status: 'success',
-          duration: 3000,
-          description: '회원가입이 완료되었습니다',
-          title: '계정 생성완료',
-          isClosable: true,
-        })
-        navigate('/login')
-      } else {
-        setBtnUI('Invalid')
+    if (contentUI === 'Password') {
+      setErrorText('')
+      const passwordRegex = /(?=.*\d)(?=.*[a-z]).{8,}/
+      if (!passwordRegex.test(input.password)) {
+        setErrorText(
+          '영문과 숫자를 포함한 8자리 이상의 비밀번호를 설정해주세요',
+        )
+        return
       }
-    } else {
-      // passwordRef.current && passwordRef.current.focus()
-      setErrorText('비밀번호가 일치하지 않습니다')
+      if (input.password === input.passwordConfirm) {
+        const response = await postRegister({
+          username: input.username,
+          verificationCode: input.verificationCode,
+          password: input.password,
+        })
+        const status = response.status
+        const message = response.data.message
+        setErrorText(message)
+
+        if (status < 400) {
+          toast({
+            status: 'success',
+            duration: 3000,
+            description: '회원가입이 완료되었습니다',
+            title: '계정 생성완료',
+            isClosable: true,
+          })
+          navigate('/login')
+        } else {
+          setBtnUI('Invalid')
+        }
+      } else {
+        // passwordRef.current && passwordRef.current.focus()
+        setErrorText('비밀번호가 일치하지 않습니다')
+      }
     }
   }
 
@@ -221,12 +225,6 @@ const Register = (): JSX.Element => {
               <RegisterButton onClick={handleAgreeBtn}>
                 다음 단계
               </RegisterButton>
-              <Text align="center">
-                이미 가입하셨나요?{' '}
-                <Link to="/login" style={{ textDecoration: 'underline' }}>
-                  로그인
-                </Link>
-              </Text>
             </>
           )}
           {contentUI === 'Email' && (
@@ -301,6 +299,12 @@ const Register = (): JSX.Element => {
               회원가입
             </RegisterButton>
           )}
+          <Text align="center">
+            이미 가입하셨나요?{' '}
+            <Link to="/login" style={{ textDecoration: 'underline' }}>
+              로그인
+            </Link>
+          </Text>
           <ErrorText>{errorText}</ErrorText>
         </RegisterStack>
       </form>


### PR DESCRIPTION
## 개요
회원가입 페이지에 약관동의를 하지않고 다음단계를 눌렀을 때와 인증코드로직에서
 비밀번호 설정과 관련된 에러메시지가 나옵니다.

## 미리보기
![image](https://user-images.githubusercontent.com/80830981/158067912-de39d327-cf88-49d9-9c7b-f922f48d7da5.png)
![image](https://user-images.githubusercontent.com/80830981/158067968-193a6f8e-c587-4bad-8e6b-680525068400.png)


## 상세 설명

handleSubmit에 마지막 로직인 비밀번호 설정로직이 담겨있어서 생긴 이슈였습니다.
1. contentUI가 Password일 때만 비밀번호 설정로직을 처리하게 if문으로 감싸두었습니다.

## 기타

이후 handleSubmit함수가 다른 함수들을 감쌀 수 있게 정리가 필요해보입니다.

Close #이슈\_번호
