### PR TITLE
chore:청원반려로 title 수정&반려된 청원의 청원동의막는 로직 추가

### DIFF
--- a/src/pages/Petition/PetitionContents/index.tsx
+++ b/src/pages/Petition/PetitionContents/index.tsx
@@ -111,7 +111,7 @@ const PetitionContents = ({
                     : petition?.expired
                     ? '청원기간만료'
                     : petition?.rejected
-                    ? '반려된청원'
+                    ? '청원반려'
                     : petition?.released
                     ? '청원진행중'
                     : '사전동의진행중'}
@@ -216,7 +216,7 @@ const PetitionContents = ({
               <span className="num_of_agree">
                 청원동의 <span>{petition?.agreeCount} </span>명
               </span>
-              {!petition?.expired && (
+              {!petition?.expired && !petition?.rejected && (
                 <AgreementForm {...agreementFormProps}></AgreementForm>
               )}
               <AgreementList {...agreementListProps} />


### PR DESCRIPTION
## 개요

반려된 청원이었던 청원 상세페이지 타이틀을 청원바려로 수정하고 동의하기를 막습니다.

## 미리보기

![image](https://user-images.githubusercontent.com/80830981/161434411-6e711e2b-ce0e-4604-b7b5-bca7900a930b.png)
![image](https://user-images.githubusercontent.com/80830981/161434414-ff4b3b12-654f-4d50-ada5-a3c81077f494.png)


## 상세 설명

1.title을 청원반려로 수정했습니다.
2. 반려된 청원의 동의를 더이상 할 수 없게 막았습니다.

## 기타

Close #이슈\_번호
