### PR TITLE
feat: 메인 페이지 - 답변 대기 중인 청원 추가 & 청원 없다는 메세지 간격 줄이기

### DIFF
--- a/src/components/PetitionList/index.tsx
+++ b/src/components/PetitionList/index.tsx
@@ -26,7 +26,6 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
   )
 
   const [petitionList, setPetitionList] = useState<Array<Petition>>([])
-
   useEffect(() => {
     queryPost(queryParams)
   }, [location.search])
@@ -44,9 +43,15 @@ const PetitionList = ({ getPetitions }: GetPetitions): JSX.Element => {
 
       <PetitionsUl className="petition_list">
         {petitionList.length === 0 ? (
-          <div className="empty_message">
-            <span>{progress.current} 청원이 없습니다.</span>
-          </div>
+          location.pathname === '/' ? (
+            <div className="empty_message" style={{ margin: '5em 0 1em 0' }}>
+              <span>{progress.current} 청원이 없습니다.</span>
+            </div>
+          ) : (
+            <div className="empty_message">
+              <span>{progress.current} 청원이 없습니다.</span>
+            </div>
+          )
         ) : (
           <>
             {petitionList.map(petition => (

--- a/src/pages/Home/MainPetitions/index.tsx
+++ b/src/pages/Home/MainPetitions/index.tsx
@@ -1,8 +1,9 @@
 import Inner from '@components/Inner'
 import PetitionList from '@components/PetitionList'
 import {
-  getAnsweredByQuery,
   getPetitionsByQuery,
+  getWaitingByQuery,
+  getAnsweredByQuery,
   getRejectedByQuery,
 } from '@api/petitionAPI'
 import { PetitionsSection } from './styles'
@@ -17,6 +18,17 @@ const MainPetitions = (): JSX.Element => {
         <PetitionList
           getPetitions={() =>
             getPetitionsByQuery({
+              size: 5,
+              sort: 'agreeCount,desc',
+            })
+          }
+        ></PetitionList>
+        <div className="petitions_title">
+          <span>답변 대기 중인 청원</span>
+        </div>
+        <PetitionList
+          getPetitions={() =>
+            getWaitingByQuery({
               size: 5,
               sort: 'agreeCount,desc',
             })

--- a/src/utils/api/petitionAPI.ts
+++ b/src/utils/api/petitionAPI.ts
@@ -101,6 +101,18 @@ export const getAnsweredByQuery = async (query: QueryParams) => {
   return response
 }
 
+export const getWaitingByQuery = async (query: QueryParams) => {
+  const page = (Number(query?.page) || 1) - 1
+  const querystring = {
+    ...query,
+    page,
+  }
+  const response = await api.get(
+    `petitions/waitingForAnswer?${qs.stringify(querystring)}`,
+  )
+  return response
+}
+
 export const getRejectedByQuery = async (query: QueryParams) => {
   const page = (Number(query?.page) || 1) - 1
   const querystring = {


### PR DESCRIPTION
## 개요

메인 페이지에 답변 대기 중인 청원( 5개 )을 추가하였으며

청원 없다는 메세지 표시의 간격이 너무 넓어서 줄여놓았습니다.

## 미리보기

![스크린샷 2022-04-22 오전 5 23 24](https://user-images.githubusercontent.com/65757344/164546333-d90bbcc3-2445-49a3-8244-b9225aa15dc0.png)



## 기타

Close #이슈\_번호
