### PR TITLE
fix: 청원 글 쓰기 띄어쓰기 두번 연속 제한 해제

### DIFF
--- a/src/pages/Write/PostEditor/index.tsx
+++ b/src/pages/Write/PostEditor/index.tsx
@@ -52,7 +52,7 @@ const PostEditor = () => {
       }
       setPetitionInput({
         ...petitionInput,
-        [name]: value.replace(/ +/g, ' '),
+        [name]: value,
       })
     },
     [petitionInput],


### PR DESCRIPTION
## 개요

```js
  const handleChange = useCallback(( ... ) => {
      const { value, name } = e.target
      // ....
      setPetitionInput({
        ...petitionInput,
        [name]: value.replace(/ +/g, ' '),
      })
    },
    [petitionInput],
  )
```
기존 정규표현식을 사용하면 글 중간에서 띄어쓰기를 두번 하는 것 조차 막아버렸습니다.

이를 없앴습니다.

물론 띄어쓰기를 많이 해도 실제 글에는 띄어쓰기가 한번 적용되지만  
글 중간에서 띄어쓰기 두번 안되는 이슈가 더 치명적이므로 정규식을 빼도록 하겠습니다.


## 미리보기

미리보기 사진이 있다면 올려주세요.

## 상세 설명

자세한 설명을 적어주세요.

## 기타

Close #326