### PR TITLE
feat: 일부 파일 영문 번역 및 footer 내용 변경

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -10,14 +10,32 @@ const Footer = (): JSX.Element => {
         <img className="logo" alt="Logo" src={logo}></img>
         <Text>
           <a className="teamLink" href="https://www.gist-petition.com/team">
-            <span> 팀페이지로 가기</span>
+            <div>
+              <span>Better IT 팀 소개 페이지</span>
+            </div>
           </a>
           <a href="https://open.kakao.com/o/s7Qprk3d">
             <button>
-              <span>Open 채팅방</span> <RiKakaoTalkFill />
+              <div>
+                <span>오픈 채팅방</span>
+                <RiKakaoTalkFill />
+              </div>
             </button>
           </a>
-          <span>대표 이메일: rjsgh7943@gist.ac.kr</span>
+          <p>
+            <div>
+              <span>대학원 총학생회</span>
+              <span>haeinjung@gm.gist.ac.kr</span>
+            </div>
+            <div>
+              <span>비상대책위원회 소통국</span>
+              <span> heejupark@gm.gist.ac.kr</span>
+            </div>
+            <div>
+              <span>Better IT 대표</span>
+              <span> rjsgh7943@gist.ac.kr</span>
+            </div>
+          </p>
         </Text>
       </Inner>
     </FooterContainer>

--- a/src/components/Footer/styles.ts
+++ b/src/components/Footer/styles.ts
@@ -2,20 +2,26 @@ import styled from '@emotion/styled'
 import theme from '@style/theme'
 
 const FooterContainer = styled.footer`
-  height: 4rem;
+  height: 10rem;
   background-color: ${theme.color.WHITE};
   width: 100%;
+  @media screen and (min-width: ${theme.breakpoints.md}) {
+    height: 6rem;
+  }
   .inner {
     display: flex;
-    justify-content: center;
-    align-items: center;
+    flex-direction: column-reverse;
     @media screen and (min-width: ${theme.breakpoints.md}) {
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
       font-size: 0.8rem;
       flex: 20%;
     }
     .logo {
+      width: 139.5px;
       height: 4rem;
-      margin-right: 0.5em;
+      margin: 0 auto;
     }
   }
 `
@@ -23,33 +29,43 @@ const FooterContainer = styled.footer`
 const Text = styled.p`
   display: flex;
   flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  gap: 5px;
   color: ${theme.color.SECOND_Light_GRAY};
   @media screen and (min-width: ${theme.breakpoints.md}) {
+    flex-direction: row;
     font-size: 0.8rem;
     flex: 80%;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
     > .teamLink {
-      margin-left: 10em;
+      margin-left: 5em;
     }
   }
   > a {
     font-size: 0.8rem;
     margin-bottom: 0.2em;
     > button {
-      display: flex;
-      align-items: center;
-      font-size: 1.1rem;
-      > span {
+      div {
+        display: flex;
+        align-items: center;
+        font-size: 1.1rem;
+      }
+      span {
         font-size: 0.8rem;
         margin-right: 0.2em;
       }
     }
   }
-  > span {
-    font-size: 0.8rem;
-    margin-bottom: 0.2em;
+  p {
+    width: 17rem;
+    div {
+      display: flex;
+      justify-content: space-between;
+      span {
+        font-size: 0.8rem;
+        line-height: 1rem;
+      }
+    }
   }
 `
 

--- a/src/components/NavBar/MyMenu/index.tsx
+++ b/src/components/NavBar/MyMenu/index.tsx
@@ -9,6 +9,8 @@ import { useRef, useState } from 'react'
 
 import locale from './locale'
 import { useTranslate } from '@hooks/useTranslate'
+import { FaRegUser } from 'react-icons/fa'
+import { GrLogin } from 'react-icons/gr'
 
 const MyMenu = (): JSX.Element => {
   const t = useTranslate(locale)
@@ -43,7 +45,7 @@ const MyMenu = (): JSX.Element => {
           }}
         >
           <Before open={opened}></Before>
-          {t('myinfo')}
+          <FaRegUser />
         </summary>
         <div className="menu_list">
           <Link to="/mypetitions">{t('mine')}</Link>
@@ -81,7 +83,8 @@ const MyMenu = (): JSX.Element => {
           )
         }}
       >
-        {t('signin')}
+        <span className="signin__mob">{t('signin')}</span>
+        <GrLogin className="signin" style={{ marginLeft: '-20px' }} />
       </div>
     </ItemName>
   )

--- a/src/components/NavBar/MyMenu/index.tsx
+++ b/src/components/NavBar/MyMenu/index.tsx
@@ -7,7 +7,12 @@ import { useDispatch } from 'react-redux'
 import { Link, useNavigate } from 'react-router-dom'
 import { useRef, useState } from 'react'
 
+import locale from './locale'
+import { useTranslate } from '@hooks/useTranslate'
+
 const MyMenu = (): JSX.Element => {
+  const t = useTranslate(locale)
+
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const handleLogout = async () => {
@@ -37,26 +42,27 @@ const MyMenu = (): JSX.Element => {
             }
           }}
         >
-          <Before open={opened}></Before>내 정보
+          <Before open={opened}></Before>
+          {t('myinfo')}
         </summary>
         <div className="menu_list">
-          <Link to="/mypetitions">나의 청원</Link>
+          <Link to="/mypetitions">{t('mine')}</Link>
           <div role="none" className="dropdown_divider"></div>
-          <a href="/myinfo">회원 정보 관리</a>
-          <a onClick={handleLogout}>로그아웃</a>
+          <a href="/myinfo">{t('account')}</a>
+          <a onClick={handleLogout}>{t('signout')}</a>
         </div>
       </details>
 
       <MobileMenu>
         <ItemName>
-          <Link to="/mypetitions">나의 청원</Link>
+          <Link to="/mypetitions">{t('mine')}</Link>
         </ItemName>
         <ItemName>
-          <a href="/myinfo">회원 정보 관리</a>
+          <a href="/myinfo">{t('account')}</a>
         </ItemName>
         <ItemName>
           <Link to="#" onClick={handleLogout}>
-            로그아웃
+            {t('signout')}
           </Link>
         </ItemName>
       </MobileMenu>
@@ -75,7 +81,7 @@ const MyMenu = (): JSX.Element => {
           )
         }}
       >
-        로그인
+        {t('signin')}
       </div>
     </ItemName>
   )

--- a/src/components/NavBar/MyMenu/locale.ts
+++ b/src/components/NavBar/MyMenu/locale.ts
@@ -1,0 +1,18 @@
+const locale: Locale = {
+  ko: {
+    signin: '로그인',
+    myinfo: '내 정보',
+    mine: '나의 청원',
+    account: '회원 정보 관리',
+    signout: '로그아웃',
+  },
+  en: {
+    signin: 'Sigin In',
+    myinfo: 'My Info',
+    mine: 'My Petitions',
+    account: 'Account Setting',
+    signout: 'Sign Out',
+  },
+}
+
+export default locale

--- a/src/components/NavBar/MyMenu/locale.ts
+++ b/src/components/NavBar/MyMenu/locale.ts
@@ -7,7 +7,7 @@ const locale: Locale = {
     signout: '로그아웃',
   },
   en: {
-    signin: 'Sigin In',
+    signin: 'Sign In',
     myinfo: 'My Info',
     mine: 'My Petitions',
     account: 'Account Setting',

--- a/src/components/NavBar/MyMenu/styles.ts
+++ b/src/components/NavBar/MyMenu/styles.ts
@@ -15,7 +15,7 @@ const Container = styled.div`
     @media screen and (min-width: ${theme.breakpoints.md}) {
       display: block;
       font-size: 1.125rem;
-      margin: 0px 0px 5px 40px;
+      margin: 0px 0px 5px 20px;
       padding: 5px 0px 3px 0px;
     }
 
@@ -64,7 +64,7 @@ const Container = styled.div`
       background-color: #fff;
       ::before {
         top: -19px;
-        right: 24px;
+        right: 9px;
         border: 9px solid transparent;
         border-bottom-color: #e0e0e0;
         position: absolute;
@@ -72,7 +72,7 @@ const Container = styled.div`
       }
       ::after {
         top: -16px;
-        right: 25px;
+        right: 10px;
         border: 8px solid transparent;
         border-bottom-color: #fff;
         position: absolute;

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -53,17 +53,17 @@ const NavBar = (): JSX.Element => {
             </ListItem>
             <ListItem>
               <ItemName>
-                <Link to={writePathname}>청원하기</Link>
+                <Link to={writePathname}>{t('petition')}</Link>
               </ItemName>
             </ListItem>
             <ListItem>
               <ItemName>
-                <Link to="/petitions">모든 청원</Link>
+                <Link to="/petitions">{t('all')}</Link>
               </ItemName>
             </ListItem>
             <ListItem>
               <ItemName>
-                <Link to="/answer">답변된 청원</Link>
+                <Link to="/answer">{t('answered')}</Link>
               </ItemName>
             </ListItem>
             <Divider></Divider>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -11,6 +11,8 @@ import { useAppDispatch, useAppSelect } from '@redux/store.hooks'
 import { toggleLang } from '@redux/lang/langSlice'
 import locale from './locale'
 import { useTranslate } from '@hooks/useTranslate'
+import { MdGTranslate, MdTranslate } from 'react-icons/md'
+
 const NavBar = (): JSX.Element => {
   const [opened, setOpened] = useState<boolean>(false)
   const isAuthorized = useAppSelect(select => select.auth.isAuthorized)
@@ -41,13 +43,6 @@ const NavBar = (): JSX.Element => {
           <div onClick={closeMenu}>
             <ListItem>
               <ItemName>
-                <div onClick={handleLangChange}>
-                  {useAppSelect(select => select.lang.mode)}
-                </div>
-              </ItemName>
-            </ListItem>
-            <ListItem>
-              <ItemName>
                 <Link to="/guide">{t('about')}</Link>
               </ItemName>
             </ListItem>
@@ -66,6 +61,13 @@ const NavBar = (): JSX.Element => {
                 <Link to="/answer">{t('answered')}</Link>
               </ItemName>
             </ListItem>
+            <ListItem>
+              <ItemName className="translate-btn">
+                <div onClick={handleLangChange}>
+                  <MdTranslate />
+                </div>
+              </ItemName>
+            </ListItem>
             <Divider></Divider>
             <ListItem>
               <MyMenu />
@@ -80,6 +82,9 @@ const NavBar = (): JSX.Element => {
         >
           <MobMenuIcon />
         </MobMenuButton>
+        <div className="translate-btn__mob" onClick={handleLangChange}>
+          <MdTranslate />
+        </div>
       </Inner>
     </Header>
   )

--- a/src/components/NavBar/locale.ts
+++ b/src/components/NavBar/locale.ts
@@ -1,9 +1,15 @@
 const locale: Locale = {
   ko: {
     about: '이용안내',
+    petition: '청원하기',
+    all: '모든 청원',
+    answered: '답변된 청원',
   },
   en: {
-    about: 'about',
+    about: 'About',
+    petition: 'Make Petition',
+    all: 'All Petitions',
+    answered: 'Answered Petitions',
   },
 }
 

--- a/src/components/NavBar/styles.ts
+++ b/src/components/NavBar/styles.ts
@@ -25,6 +25,29 @@ const Header = styled.header`
       padding: 0 ${theme.space.INNER_PADDING};
       flex-direction: row;
     }
+    .translate-btn {
+      display: none;
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        display: block;
+      }
+    }
+    .translate-btn__mob {
+      svg {
+        height: 100%;
+        width: 24px;
+        margin: auto;
+      }
+      position: absolute;
+      height: 100%;
+      width: 60px;
+      right: 0;
+      :hover {
+        cursor: pointer;
+      }
+      @media screen and (min-width: ${theme.breakpoints.md}) {
+        display: none;
+      }
+    }
   }
 `
 
@@ -87,12 +110,24 @@ const ItemName = styled.div`
       text-underline-position: under;
     }
   }
+
+  .signin__mob {
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      display: none;
+    }
+  }
+  .signin {
+    display: none;
+    @media screen and (min-width: ${theme.breakpoints.md}) {
+      display: block;
+    }
+  }
 `
 
 const MobMenuButton = styled(Button)`
   border-radius: 0;
   position: absolute;
-  right: 0;
+  left: 0;
   height: 100%;
   transform: ${props => (props.open ? 'rotate(-90deg)' : 'none')};
   display: block;

--- a/src/components/UserInput/index.tsx
+++ b/src/components/UserInput/index.tsx
@@ -71,7 +71,6 @@ const UserInput = memo(
     return (
       <SUserInput>
         <FormControl isRequired>
-          <span className="page_type">{text}</span>
           <InputGroup borderColor={`${theme.color.ligthGray}`}>
             <InputLeftElement>
               {<WhichIcon color="gray.300"></WhichIcon>}

--- a/src/pages/Guide/index.tsx
+++ b/src/pages/Guide/index.tsx
@@ -7,7 +7,6 @@ import {
   StepHeadContainer,
 } from './styles'
 import { Stack, Heading } from '@chakra-ui/react'
-import { ChevronRightIcon } from '@chakra-ui/icons'
 import { Link } from 'react-router-dom'
 
 const Guide = (): JSX.Element => {
@@ -24,9 +23,14 @@ const Guide = (): JSX.Element => {
               <p>
                 지스트 청원은 학생들이 학교운영과 관련된 의견을 공유하고, 이에
                 대한 요구를 학교 측에 제시하여 직접 답변을 받을 수 있는
-                서비스입니다. 지스트 청원은 학생 개발팀 Better IT팀과 대학원
-                총학생회에서 관리하고 있으며, 학생과 학교 간의 직접 소통을
-                지향합니다.
+                서비스입니다. 지스트 청원의 개발은{' '}
+                <a href="https://www.gist-petition.com/team">
+                  <span className="strong">Better IT팀</span>
+                </a>
+                이 맡고 있고, 게시판 운영은{' '}
+                <span className="strong">대학원 총학생회</span>와{' '}
+                <span className="strong">비상대책위원회 소통국</span>에서
+                관리하고 있으며, 학생과 학교 간의 직접 소통을 지향합니다.
               </p>
             </div>
           </ContentContainer>
@@ -142,7 +146,7 @@ const Guide = (): JSX.Element => {
             <li className="step-content">
               <div className="content-wrap">
                 <div>
-                  50명 이상의 청원동의를 받은 청원은 대학원 학생회를 통해 원내
+                  50명 이상의 청원동의를 받은 청원은 대학원 총학생회를 통해 원내
                   관련 부서에 전달됩니다. 청원에 대한 답변은 답변 현황 페이지에
                   게시됩니다.
                 </div>

--- a/src/pages/Guide/styles.ts
+++ b/src/pages/Guide/styles.ts
@@ -37,6 +37,9 @@ const ContentContainer = styled.div`
     color: ${theme.color.QUATERNARY_GRAY};
     background: #cccccc82;
     line-height: 1.3;
+    a {
+      text-decoration: underline;
+    }
   }
 `
 const StepHeadContainer = styled.ul`

--- a/src/pages/Home/Banner/index.tsx
+++ b/src/pages/Home/Banner/index.tsx
@@ -3,8 +3,12 @@ import Inner from '@components/Inner'
 import { useEffect, useState } from 'react'
 import { BannerSection } from './styles'
 import qs from 'qs'
+import { useTranslate } from '@hooks/useTranslate'
+import locale from './locale'
 
 const Banner = (): JSX.Element => {
+  const t = useTranslate(locale)
+
   const queryParams: any = qs.parse(location.search, {
     ignoreQueryPrefix: true,
   })
@@ -30,11 +34,14 @@ const Banner = (): JSX.Element => {
           <Inner>
             <div className="banner_dashboard">
               <span>
-                지금까지 총 <span>{petitionCount}</span> 개의 청원과
+                {t('above1')}
+                <span>{petitionCount}</span>
+                {t('above2')}
               </span>
               <span>
                 <span>
-                  <span>{answeredCount}</span> 개의 답변이 등록됐습니다
+                  <span>{answeredCount}</span>
+                  {t('below')}
                 </span>
               </span>
             </div>

--- a/src/pages/Home/Banner/locale.ts
+++ b/src/pages/Home/Banner/locale.ts
@@ -1,0 +1,14 @@
+const locale: Locale = {
+  ko: {
+    above1: '지금까지 총 ',
+    above2: ' 개의 청원과 ',
+    below: ' 개의 답변이 등록되었습니다',
+  },
+  en: {
+    above1: 'Total ',
+    above2: ' petitions are requested, ',
+    below: ' are answered',
+  },
+}
+
+export default locale

--- a/src/pages/Home/MainPetitions/index.tsx
+++ b/src/pages/Home/MainPetitions/index.tsx
@@ -16,7 +16,7 @@ const MainPetitions = (): JSX.Element => {
     <PetitionsSection>
       <Inner>
         <div className="petitions_title">
-          <span>추천순 TOP 5</span>
+          <span>{t('recommened')}</span>
         </div>
         <PetitionList
           getPetitions={() =>
@@ -27,7 +27,7 @@ const MainPetitions = (): JSX.Element => {
           }
         ></PetitionList>
         <div className="petitions_title">
-          <span>답변 대기 중인 청원</span>
+          <span>{t('waiting')}</span>
         </div>
         <PetitionList
           getPetitions={() =>

--- a/src/pages/Home/MainPetitions/locale.ts
+++ b/src/pages/Home/MainPetitions/locale.ts
@@ -1,11 +1,15 @@
 const locale: Locale = {
   ko: {
+    recommened: '추천순 TOP 5',
+    waiting: '답변 대기중인 청원',
     recent: '최근 답변된 청원',
     reject: '최근 반려된 청원',
   },
   en: {
-    recent: 'Recently answered petition',
-    reject: 'Recently rejected petition',
+    recommened: 'Recommened TOP 5',
+    waiting: 'Waiting For Answer',
+    recent: 'Recently Answered Petition',
+    reject: 'Recently Rejected Petition',
   },
 }
 

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -16,8 +16,12 @@ import { FaUserAlt, FaLock } from 'react-icons/fa'
 import { postLogin } from '@api/userAPI'
 import { useAppDispatch, useAppSelect } from '@redux/store.hooks'
 import { ViewOffIcon, ViewIcon } from '@chakra-ui/icons'
+import { useTranslate } from '@hooks/useTranslate'
+import locale from './locale'
 
 const Login = (): JSX.Element => {
+  const t = useTranslate(locale)
+
   const CFaUserAlt = chakra(FaUserAlt)
   const CFaLock = chakra(FaLock)
 
@@ -93,9 +97,8 @@ const Login = (): JSX.Element => {
     <Container>
       <form className="login_form" onSubmit={handleSubmit}>
         <Stack spacing={4}>
-          <span>로그인</span>
+          <span>{t('signin')}</span>
           <FormControl isRequired>
-            <span>이메일</span>
             <InputGroup>
               <InputLeftElement pointerEvents="none">
                 {<CFaUserAlt color="gray.300" />}
@@ -105,12 +108,11 @@ const Login = (): JSX.Element => {
                 type="email"
                 name="username"
                 id="uesrname"
-                placeholder="지스트 이메일을 입력하세요"
+                placeholder={t('email')}
               />
             </InputGroup>
           </FormControl>
           <FormControl>
-            <span>비밀번호</span>
             <InputGroup>
               <InputLeftElement pointerEvents="none">
                 {<CFaLock color="gray.300" />}
@@ -120,7 +122,7 @@ const Login = (): JSX.Element => {
                 type={viewPassword ? 'text' : 'password'}
                 name="password"
                 id="password"
-                placeholder="비밀번호를 입력하세요"
+                placeholder={t('password')}
                 onKeyPress={checkUpperCase}
               />
               <InputRightElement>
@@ -136,7 +138,7 @@ const Login = (): JSX.Element => {
           </FormControl>
           <span className="err_msg">{checkLoginError(responseState)}</span>
           <span className="forgot_pwd account_link">
-            <Link to="/findpassword">비밀번호를 잊으셨나요?</Link>
+            <Link to="/findpassword">{t('forgotPwd')}</Link>
           </span>
 
           <button
@@ -149,11 +151,11 @@ const Login = (): JSX.Element => {
               })
             }}
           >
-            로그인
+            {t('signin')}
           </button>
 
           <span className="create_account account_link">
-            계정이 없으신가요?{' '}
+            {t('signupMsg')}{' '}
             <a
               onClick={_e => {
                 navigate(
@@ -162,7 +164,7 @@ const Login = (): JSX.Element => {
                 )
               }}
             >
-              회원가입
+              {t('signup')}
             </a>
           </span>
         </Stack>

--- a/src/pages/Login/locale.ts
+++ b/src/pages/Login/locale.ts
@@ -1,0 +1,20 @@
+const locale: Locale = {
+  ko: {
+    signin: '로그인',
+    email: '지스트 이메일을 입력하세요',
+    password: '비밀번호를 입력하세요',
+    forgotPwd: '비밀번호를 잊으셨나요?',
+    signupMsg: '계정이 없으신가요?',
+    signup: '회원가입',
+  },
+  en: {
+    signin: 'Sign In',
+    email: 'GIST e-mail',
+    password: 'Password',
+    forgotPwd: 'Forgot password?',
+    signupMsg: "Don't have an account?",
+    signup: 'Sign Up',
+  },
+}
+
+export default locale

--- a/src/pages/Login/styles.ts
+++ b/src/pages/Login/styles.ts
@@ -15,10 +15,6 @@ const Container = styled.section`
     }
 
     .chakra-form-control {
-      > span {
-        display: inline-block;
-        margin-bottom: 0.5rem;
-      }
       .chakra-input__group {
         border-color: #ccc;
         .chakra-input {

--- a/src/pages/Register/index.tsx
+++ b/src/pages/Register/index.tsx
@@ -4,14 +4,13 @@ import {
   postCreateVerificationCode,
 } from '@api/verificationAPI'
 import { postRegister } from '@api/userAPI'
-import { Text, useToast } from '@chakra-ui/react'
+import { useToast } from '@chakra-ui/react'
 import { RegisterStack, RegisterButton, ErrorText } from './styles'
 import { useNavigate } from 'react-router-dom'
 import TermsOfUse from './TermsOfUse'
 import LoadingSpinner from '@components/LoadingSpinner'
 import UserInput from '@components/UserInput'
 import { useAppSelect } from '@redux/store.hooks'
-import { Link } from 'react-router-dom'
 import Email from '../../components/Email'
 import EmailAndVerification from '../../components/EmailAndVerification'
 


### PR DESCRIPTION
## 개요

- Main Petitions, NavBar, Banner, Login 파일 영문 번역 추가했습니다.
- 이용 안내 페이지 better-IT 팀페이지 링크 걸어두었고, 운영 주체 비대위 소통국 추가했습니다.

## 미리보기

<img width="936" alt="스크린샷 2022-05-27 오전 10 09 52" src="https://user-images.githubusercontent.com/65757344/170608525-18d17ae2-5944-4f2f-bf1e-ebc34c0ca2da.png">

<img width="490" alt="스크린샷 2022-05-27 오전 10 10 01" src="https://user-images.githubusercontent.com/65757344/170608538-917a9d8b-4b9f-4a75-be7b-21f4fd21bf71.png">


## 상세 설명

번역 버튼이랑, 로그인 버튼은 아이콘으로 만들어서 오른쪽에 따로 빼둬야될 것 같습니다.



