### PR TITLE
게시글 category에 자치회 항목 추가

### DIFF
--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -8,6 +8,7 @@ export enum koCategory {
   '기획/예산/홍보',
   '대외협력',
   '권익소통',
+  '자치회',
   '기타',
 }
 
@@ -21,5 +22,6 @@ export enum enCategory {
   'planning/budget/public relations',
   'external cooperation',
   'rights/interest communication',
+  'student council',
   'etc',
 }


### PR DESCRIPTION
## 개요

현 소통국장 카톡 요청 사항
> 안녕하세요! 지스트 집행위원회 소통국장입니다. 
최근 학생회의에서 지스트 청원 사이트 청원 분류 카테고리에 "**자치회**"를 추가하자는 의견이 나왔습니다. 카테고리에 "**자치회**" 항목을 추가해주실 수 있나요? 갑작스럽게 부탁드려 죄송합니다.
> 6월부터 학생회 인스타그램과 각 학번 학생 톡방을 이용해 지스트청원을 적극적으로 홍보할 계획입니다. 

![image](https://user-images.githubusercontent.com/65757344/229340190-34d170c9-2f53-4e65-9b43-52ce33c43d68.png)


## 기타

Close #343 
